### PR TITLE
Feature/explicit duration list

### DIFF
--- a/perm_revoker_lambda.tf
+++ b/perm_revoker_lambda.tf
@@ -63,6 +63,7 @@ module "access_revoker" {
     SSO_ELEVATOR_SCHEDULED_REVOCATION_RULE_NAME = aws_cloudwatch_event_rule.sso_elevator_scheduled_revocation.name
     REQUEST_EXPIRATION_HOURS                    = var.request_expiration_hours
     MAX_PERMISSIONS_DURATION_TIME               = var.max_permissions_duration_time
+    PERMISSION_DURATION_LIST_OVERRIDE           = jsonencode(var.permission_duration_list_override)
 
     APPROVER_RENOTIFICATION_INITIAL_WAIT_TIME  = var.approver_renotification_initial_wait_time
     APPROVER_RENOTIFICATION_BACKOFF_MULTIPLIER = var.approver_renotification_backoff_multiplier

--- a/slack_handler_lambda.tf
+++ b/slack_handler_lambda.tf
@@ -64,6 +64,7 @@ module "access_requester_slack_handler" {
     APPROVER_RENOTIFICATION_INITIAL_WAIT_TIME   = var.approver_renotification_initial_wait_time
     APPROVER_RENOTIFICATION_BACKOFF_MULTIPLIER  = var.approver_renotification_backoff_multiplier
     MAX_PERMISSIONS_DURATION_TIME               = var.max_permissions_duration_time
+    PERMISSION_DURATION_LIST_OVERRIDE           = jsonencode(var.permission_duration_list_override)
     SECONDARY_FALLBACK_EMAIL_DOMAINS            = jsonencode(var.secondary_fallback_email_domains)
     SEND_DM_IF_USER_NOT_IN_CHANNEL              = var.send_dm_if_user_not_in_channel
   }

--- a/src/config.py
+++ b/src/config.py
@@ -94,6 +94,7 @@ class Config(BaseSettings):
     request_expiration_hours: int = 8
 
     max_permissions_duration_time: int
+    permission_duration_list_override: list
 
     good_result_emoji: str = ":large_green_circle:"
     waiting_result_emoji: str = ":large_yellow_circle:"

--- a/src/slack_helpers.py
+++ b/src/slack_helpers.py
@@ -453,14 +453,26 @@ def get_message_from_timestamp(channel_id: str, message_ts: str, slack_client: s
 # Plain text object supports only 99 options
 # https://github.com/fivexl/terraform-aws-sso-elevator/issues/110
 def get_max_duration_block(cfg: config.Config) -> list[Option]:
-    max_increments = min(cfg.max_permissions_duration_time * 2, 99)
-    return [
-        Option(
-            text=PlainTextObject(text=f"{i // 2:02d}:{(i % 2) * 30:02d}"),
-            value=f"{i // 2:02d}:{(i % 2) * 30:02d}"
-        )
-        for i in range(1, max_increments + 1)
-    ]
+    if cfg.permission_duration_list_override:
+        elements = cfg.permission_duration_list_override
+        if len(elements) > 100
+            elements = elements[:99] + elements[-1:]
+        return [
+            Option(
+                text=PlainTextObject(text=s),
+                value=s
+            )
+            for s in elements
+        ]
+    else:
+        max_increments = min(cfg.max_permissions_duration_time * 2, 99)
+        return [
+            Option(
+                text=PlainTextObject(text=f"{i // 2:02d}:{(i % 2) * 30:02d}"),
+                value=f"{i // 2:02d}:{(i % 2) * 30:02d}"
+            )
+            for i in range(1, max_increments + 1)
+        ]
 
 
 # Group

--- a/src/slack_helpers.py
+++ b/src/slack_helpers.py
@@ -455,7 +455,7 @@ def get_message_from_timestamp(channel_id: str, message_ts: str, slack_client: s
 def get_max_duration_block(cfg: config.Config) -> list[Option]:
     if cfg.permission_duration_list_override:
         elements = cfg.permission_duration_list_override
-        if len(elements) > 100
+        if len(elements) > 100:
             elements = elements[:99] + elements[-1:]
         return [
             Option(

--- a/vars.tf
+++ b/vars.tf
@@ -231,11 +231,17 @@ variable "max_permissions_duration_time" {
 variable "permission_duration_list_override" {
   description = <<EOT
   An explicit list of duration values to appear in the drop-down menu users use to select how long to request permissions for.
-  Each entry in the list should be formatted as "hh:mm", e.g. "01:30" for an hour and a half.
+  Each entry in the list should be formatted as "hh:mm", e.g. "01:30" for an hour and a half. Note that while the number of minutes
+  must be between 0-59, the number of hours can be any number.
   If this variable is set, the max_permission_duration_time is ignored.
   EOT
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = alltrue([for d in var.permission_duration_list_override : can(regex("^\\d+:[0-5]\\d$", d))])
+    error_message = "Each entry in the permission_duration_list_override must be in the format hh:mm, that is, a number of hours, followed by a colon, followed by a number of minutes."
+  }
 }
 
 variable "logs_retention_in_days" {

--- a/vars.tf
+++ b/vars.tf
@@ -228,6 +228,16 @@ variable "max_permissions_duration_time" {
   default     = 24
 }
 
+variable "permission_duration_list_override" {
+  description = <<EOT
+  An explicit list of duration values to appear in the drop-down menu users use to select how long to request permissions for.
+  Each entry in the list should be formatted as "hh:mm", e.g. "01:30" for an hour and a half.
+  If this variable is set, the max_permission_duration_time is ignored.
+  EOT
+  type        = list(string)
+  default     = []
+}
+
 variable "logs_retention_in_days" {
   description = "The number of days you want to retain log events in the log group for both Lambda functions and API Gateway."
   type        = number


### PR DESCRIPTION
This attempts to address #110 in a slightly more thorough way, allowing users who wish to exceed 48 hours as their max duration to do so by specifying an explicit list of values to supply in the drop down; it also has the side effect of allowing people who are fine with 48 hours or less to trim their list by omitting some of the increments.

Example usage:

```
module "aws_sso_elevator {
  source  = "fivexl/sso-elevator/aws"
  version = "3.0.0"

  ...
  permission_duration_list_override = ["00:30","01:00","02:00","03:00","06:00","12:00","24:00","48:00","72:00","96:00"]
  ... 
}
```

Resulting display:
![image](https://github.com/user-attachments/assets/17c20a54-d521-4591-988f-3d7536f22022)

I think it might have been even nicer to allow specifying times with e.g. "1h30m", but, this method was simpler to integrate into the existing code.