### PR TITLE
Add api gateway name variable with backward compatibility

### DIFF
--- a/slack_handler_lambda.tf
+++ b/slack_handler_lambda.tf
@@ -227,7 +227,7 @@ module "http_api" {
   count         = var.create_api_gateway ? 1 : 0
   source        = "terraform-aws-modules/apigateway-v2/aws"
   version       = "5.0.0"
-  name          = "sso-elevator-access-requster"
+  name          = var.api_gateway_name
   description   = "API Gateway for SSO Elevator's access-requester Lambda, to communicate with Slack"
   protocol_type = "HTTP"
 

--- a/vars.tf
+++ b/vars.tf
@@ -311,6 +311,12 @@ variable "api_gateway_throttling_rate_limit" {
   default     = 1
 }
 
+variable "api_gateway_name" {
+  description = "The name of the API Gateway for SSO Elevator's access-requester Lambda"
+  type        = string
+  default     = "sso-elevator-access-requster"
+}
+
 variable "send_dm_if_user_not_in_channel" {
   type        = bool
   default     = true


### PR DESCRIPTION
Add `api_gateway_name` variable to allow customization of the API Gateway name, defaulting to the existing value for backward compatibility.

The existing API Gateway name `sso-elevator-access-requster` contained a typo ('requster' instead of 'requester'). As requested, this typo is preserved in the default value of the new `api_gateway_name` variable to ensure backward compatibility for existing deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-86ead2b6-3ab0-4cf1-bd60-f9183bd33cd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86ead2b6-3ab0-4cf1-bd60-f9183bd33cd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>