### PR TITLE
Fix #126: revoker lambda s3 bucket config

### DIFF
--- a/perm_revoker_lambda.tf
+++ b/perm_revoker_lambda.tf
@@ -63,6 +63,7 @@ module "access_revoker" {
     REQUEST_EXPIRATION_HOURS                    = var.request_expiration_hours
     MAX_PERMISSIONS_DURATION_TIME               = var.max_permissions_duration_time
     PERMISSION_DURATION_LIST_OVERRIDE           = jsonencode(var.permission_duration_list_override)
+    CONFIG_BUCKET_NAME                          = local.config_bucket_name
     CONFIG_S3_KEY                               = "config/approval-config.json"
 
     APPROVER_RENOTIFICATION_INITIAL_WAIT_TIME  = var.approver_renotification_initial_wait_time
@@ -168,6 +169,18 @@ data "aws_iam_policy_document" "revoker" {
       "identitystore:DeleteGroupMembership"
     ]
     resources = ["*"]
+  }
+  statement {
+    sid    = "AllowS3Config"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.config_bucket.s3_bucket_arn,
+      "${module.config_bucket.s3_bucket_arn}/*"
+    ]
   }
 
 }


### PR DESCRIPTION
Add `CONFIG_BUCKET_NAME` environment variable and S3 read permissions to the revoker lambda to enable it to load approval configurations.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ee0ebec-42fe-4ec2-85e8-c40dbdfb072f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ee0ebec-42fe-4ec2-85e8-c40dbdfb072f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>