### PR TITLE
fix(aws-provider): fivexl/account-baseline/aws//modules/s3_baseline version bump

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,7 +1,7 @@
 module "audit_bucket" {
   count   = var.s3_name_of_the_existing_bucket == "" ? 1 : 0
   source  = "fivexl/account-baseline/aws//modules/s3_baseline"
-  version = "1.5.0"
+  version = "2.0.0"
 
   bucket_name = local.s3_bucket_name
 
@@ -18,7 +18,7 @@ module "audit_bucket" {
 
 module "config_bucket" {
   source  = "fivexl/account-baseline/aws//modules/s3_baseline"
-  version = "1.5.0"
+  version = "2.0.0"
 
   bucket_name = local.config_bucket_name
 


### PR DESCRIPTION
AWS-Provider v6 support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `fivexl/account-baseline/aws//modules/s3_baseline` from `1.5.0` to `2.0.0` for `audit_bucket` and `config_bucket` modules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b51b79f73d0dd497a6a7f6a5676ec59a122e82c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->