### PR TITLE
Delete schedules after execution

### DIFF
--- a/src/schedule.py
+++ b/src/schedule.py
@@ -150,6 +150,7 @@ def schedule_revoke_event(
     )
     logger.debug("Creating schedule", extra={"revoke_event": revoke_event})
     return schedule_client.create_schedule(
+        ActionAfterCompletion="DELETE",
         FlexibleTimeWindow={"Mode": "OFF"},
         Name=schedule_name,
         GroupName=cfg.schedule_group_name,
@@ -187,6 +188,7 @@ def schedule_group_revoke_event(
     get_and_delete_scheduled_revoke_event_if_already_exist(schedule_client, group_assignment)
     logger.debug("Creating schedule", extra={"revoke_event": revoke_event})
     return schedule_client.create_schedule(
+        ActionAfterCompletion="DELETE",
         FlexibleTimeWindow={"Mode": "OFF"},
         Name=schedule_name,
         GroupName=cfg.schedule_group_name,
@@ -227,6 +229,7 @@ def schedule_discard_buttons_event(
         },
     )
     return schedule_client.create_schedule(
+        ActionAfterCompletion="DELETE",
         FlexibleTimeWindow={"Mode": "OFF"},
         Name=schedule_name,
         GroupName=cfg.schedule_group_name,
@@ -270,6 +273,7 @@ def schedule_approver_notification_event(
         },
     )
     return schedule_client.create_schedule(
+        ActionAfterCompletion="DELETE",
         FlexibleTimeWindow={"Mode": "OFF"},
         Name=schedule_name,
         GroupName=cfg.schedule_group_name,


### PR DESCRIPTION
When access is granted, an EventBridgeSchedule is created to fire when access should be revoked.  However the schedules are not deleted, and so the list of schedules continues to grow, for ever.

This has the knock-on effect of making the revoke lambda run slower and slower, as it has to paginate through more and more old schedules.

This commit sets the ActionAfterCompletion property on the schedule so that once it has executed AWS will delete it.  This means that the number of schedules should remain fairly constant over a given period of time.

Note that I have not included anything here to delete old schedules, so tidying-up an existing installation will be something that each team will need to perform manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets ActionAfterCompletion=DELETE on all created EventBridge schedules so they are removed after firing.
> 
> - **Scheduler**:
>   - Set `ActionAfterCompletion` to `DELETE` for schedules created in:
>     - `schedule_revoke_event`
>     - `schedule_group_revoke_event`
>     - `schedule_discard_buttons_event`
>     - `schedule_approver_notification_event`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be0f8c13199b996fc942311dc7ab75dabeca6ef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->