### PR TITLE
[fix] Use fresh groups data for cache update

### DIFF
--- a/src/attribute_syncer.py
+++ b/src/attribute_syncer.py
@@ -407,7 +407,7 @@ def perform_sync(ctx: SyncContext) -> SyncOperationResult:  # noqa: PLR0912, PLR
         # Step 4: Get managed groups with current membership
         logger.info("Fetching managed groups and membership state")
         try:
-            _, current_state = get_managed_groups(
+            fresh_groups, current_state = get_managed_groups(
                 identity_store_client=ctx.identity_store_client,
                 identity_store_id=ctx.identity_store_id,
                 s3_client=ctx.s3_client,
@@ -415,6 +415,8 @@ def perform_sync(ctx: SyncContext) -> SyncOperationResult:  # noqa: PLR0912, PLR
                 managed_group_names=list(resolved_config.managed_group_names),
             )
             result.groups_processed = len(current_state)
+            # Use fresh groups data for cache update (may be fresher than all_groups from step 1)
+            all_groups = fresh_groups
         except Exception as e:
             logger.exception(f"Failed to fetch managed groups: {e}")
             result.errors.append(f"Failed to fetch managed groups: {e}")


### PR DESCRIPTION
## Summary

Fixes a bug where the groups cache would be updated with stale data instead of fresh API data.

## Problem

In `perform_sync()`:
- Step 1 (`resolve_group_names_from_identity_store`) returns `all_groups` which may be cached (stale) data
- Step 4 (`get_managed_groups`) uses `with_cache_resilience` which fetches fresh data from the API and updates the cache
- However, the fresh groups data from step 4 was being discarded (assigned to `_`)
- Step 7 then overwrote the cache with the potentially stale `all_groups` from step 1

This defeated the cache refresh mechanism, causing the groups cache to never properly refresh with fresh API data after the initial cache population.

## Fix

Capture the fresh groups data returned by `get_managed_groups` and use it for the cache update in step 7, ensuring the cache properly refreshes with API data.