### PR TITLE
Vary permission set based on selected account

### DIFF
--- a/src/slack_helpers.py
+++ b/src/slack_helpers.py
@@ -69,13 +69,11 @@ class RequestForAccessView:
             callback_id=cls.CALLBACK_ID,
             submit=PlainTextObject(text="Request"),
             close=PlainTextObject(text="Cancel"),
-            title=PlainTextObject(text="Get AWS access"),
+            title=PlainTextObject(text="Request AWS access"),
             blocks=[
-                SectionBlock(text=MarkdownTextObject(text=":wave: Hey! Please fill form below to request AWS access.")),
-                DividerBlock(),
                 SectionBlock(
                     block_id=cls.DURATION_BLOCK_ID,
-                    text=MarkdownTextObject(text="Select the duration for which the authorization will be provided"),
+                    text=MarkdownTextObject(text="Access duration"),
                     accessory=StaticSelectElement(
                         action_id=cls.DURATION_ACTION_ID,
                         initial_option=get_max_duration_block(cfg)[0],
@@ -85,17 +83,17 @@ class RequestForAccessView:
                 ),
                 InputBlock(
                     block_id=cls.REASON_BLOCK_ID,
-                    label=PlainTextObject(text="Why do you need access?"),
+                    label=PlainTextObject(text="Reason"),
                     element=PlainTextInputElement(
                         action_id=cls.REASON_ACTION_ID,
-                        placeholder=PlainTextObject(text="Reason will be saved in audit logs. Please be specific."),
+                        placeholder=PlainTextObject(text="What will this access be used for?"),
                         multiline=True,
                     ),
                 ),
                 DividerBlock(),
                 SectionBlock(
                     text=MarkdownTextObject(
-                        text="Remember to use access responsibly. All actions (AWS API calls) are being recorded.",
+                        text="Remember to use your access responsibly. All AWS actions are logged.",
                     ),
                 ),
                 SectionBlock(
@@ -117,7 +115,7 @@ class RequestForAccessView:
         sorted_accounts = sorted(accounts, key=lambda account: account.name)
         return InputBlock(
             block_id=cls.ACCOUNT_BLOCK_ID,
-            label=PlainTextObject(text="Select account"),
+            label=PlainTextObject(text="Account"),
             element=StaticSelectElement(
                 action_id=cls.ACCOUNT_ACTION_ID,
                 placeholder=PlainTextObject(text="Select account"),
@@ -132,7 +130,7 @@ class RequestForAccessView:
         sorted_permission_sets = sorted(permission_sets, key=lambda permission_set: permission_set.name)
         return InputBlock(
             block_id=cls.PERMISSION_SET_BLOCK_ID,
-            label=PlainTextObject(text="Select permission set"),
+            label=PlainTextObject(text="Permission set"),
             element=StaticSelectElement(
                 action_id=cls.PERMISSION_SET_ACTION_ID,
                 placeholder=PlainTextObject(text="Select permission set"),
@@ -544,7 +542,7 @@ class RequestForGroupAccessView:
             callback_id=cls.CALLBACK_ID,
             submit=PlainTextObject(text="Request"),
             close=PlainTextObject(text="Cancel"),
-            title=PlainTextObject(text="Get AWS access"),
+            title=PlainTextObject(text="Request AWS access"),
             blocks=[
                 SectionBlock(text=MarkdownTextObject(text=":wave: Hey! Please fill form below to request access to AWS SSO group.")),
                 DividerBlock(),

--- a/src/statement.py
+++ b/src/statement.py
@@ -40,6 +40,17 @@ def get_affected_statements(statements: FrozenSet[Statement], account_id: str, p
     return frozenset(statement for statement in statements if statement.affects(account_id, permission_set_name))
 
 
+def get_permission_sets_for_account(statements: FrozenSet[Statement], account_id: str) -> set[str]:
+    """Return permission set names valid for given account based on statements."""
+    permission_sets: set[str] = set()
+    for statement in statements:
+        if account_id in statement.resource or "*" in statement.resource:
+            if "*" in statement.permission_set:
+                return {"*"}
+            permission_sets.update(statement.permission_set)
+    return permission_sets
+
+
 class OUStatement(BaseStatement):
     resource_type: ResourceType = Field(default=ResourceType.OU, frozen=True)
     resource: FrozenSet[Union[AWSOUName, WildCard]]


### PR DESCRIPTION
The slack form previously displayed all available permissions sets, regardless of the selected account. Now, the permission set list is populated based on the account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive Slack modal update logic and relies on statement-based filtering; incorrect block updates or filtering could prevent users from selecting valid permission sets or submitting requests.
> 
> **Overview**
> Updates the Slack “Request AWS access” modal to **load permission sets dynamically after an account is selected**, instead of showing all permission sets up front.
> 
> This introduces a new account-selection action handler that derives allowed permission sets from `cfg.statements` (including wildcard handling) and updates the modal to show either a filtered permission-set dropdown or a “no permission sets available” message. The initial modal population now loads *accounts only* and adds a placeholder prompt; copy in both access-request modals is also lightly revised.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b53f538c445158a181f7479c382d2656a3aab6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->