### PR TITLE
[feature] add AllowedGroups/AllowedUsers requester restrictions to statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ There are two key differences compared to the standard Elevator configuration:
 - ResourceType is not required for group access configurations.
 - In the Resource field, you must provide group IDs instead of account IDs.
 
+Group statements also support the optional `AllowedGroups` and `AllowedUsers` requester restrictions — see [Restricting who can request access](#restricting-who-can-request-access).
+
 The Elevator will only work with groups specified in the configuration.
 
 If you were using Terraform AWS SSO Elevator before version 2.0.0, you need to update your Slack app manifest by adding a new shortcut to enable this functionality:
@@ -356,7 +358,52 @@ The fields in the configuration dictionary are:
 - **Approvers**: This field lists the potential approvers for the request. It accepts either a single string or a list of strings representing different approvers.
 - **AllowSelfApproval**: This field can be a boolean, indicating whether the requester, if present in the `Approvers` list, is permitted to approve their own request. It defaults to `None`.
 - **ApprovalIsNotRequired**: This field can also be a boolean, signifying whether the approval can be granted automatically, bypassing the approvers entirely. The default value is `None`.
-- 
+- **AllowedGroups**: Optional requester restriction. A single SSO group ID or a list of SSO group IDs. If set, only members of at least one of the listed groups may request access using this statement. See [Restricting who can request access](#restricting-who-can-request-access).
+- **AllowedUsers**: Optional requester restriction. A single email or a list of emails. If set, only the listed users may request access using this statement. See [Restricting who can request access](#restricting-who-can-request-access).
+
+### Restricting who can request access
+
+By default, a statement says what can be requested and who approves it, but not who is allowed to request it — any user the Elevator can resolve in SSO can request any account/permission set (or group) that has a matching statement. The optional `AllowedGroups` and `AllowedUsers` fields restrict the requester side. They work the same way in both `config` (account statements) and `group_config` (group statements):
+
+- If both fields are omitted or empty, the statement is unrestricted — same behavior as before.
+- If either field is set, the requester must be a member of at least one group listed in `AllowedGroups` **or** be listed by email in `AllowedUsers`. Matching either one is sufficient.
+- `AllowedGroups` entries are SSO group IDs (the same format as `Resource` in `group_config`). Group membership is resolved via the IAM Identity Center `ListGroupMembershipsForMember` API using the requester's SSO user.
+- `AllowedUsers` entries are matched against the requester's email case-insensitively, including the secondary fallback domain variants if `secondary_fallback_email_domains` is configured.
+- The restriction applies to the whole statement, including `ApprovalIsNotRequired` and `AllowSelfApproval` — an ineligible requester cannot use an auto-approved statement.
+- It is enforced at both request time and approval time, so an ineligible request can't be approved either.
+- If the requester cannot be resolved to an SSO user (or group memberships can't be fetched), statements restricted with `AllowedGroups` fail closed — they are treated as not available to that requester. Unrestricted statements are unaffected.
+- If statements match the request but the requester is not eligible for any of them, the request is denied with a "not allowed to request" message.
+
+Example — developers can request `ReadOnlyAccess` themselves, but only members of the infra group (or a specific user) can request `AdministratorAccess`:
+
+```hcl
+config = [
+  {
+    "ResourceType" : "Account",
+    "Resource" : "*",
+    "PermissionSet" : "ReadOnlyAccess",
+    "Approvers" : ["lead@example.com"],
+  },
+  {
+    "ResourceType" : "Account",
+    "Resource" : "*",
+    "PermissionSet" : "AdministratorAccess",
+    "Approvers" : ["cto@example.com"],
+    "AllowedGroups" : ["99999999-8888-7777-6666-555555555555"], # infra team SSO group
+    "AllowedUsers" : ["oncall@example.com"],
+  },
+]
+
+group_config = [
+  {
+    "Resource" : ["11111111-2222-3333-4444-555555555555"], # ProdAdmins
+    "Approvers" : ["cto@example.com"],
+    "AllowedGroups" : ["99999999-8888-7777-6666-555555555555"], # infra team SSO group
+    "AllowedUsers" : ["oncall@example.com"],
+  },
+]
+```
+
 ### Explicit Deny
 In the system, an explicit denial in any statement overrides any approvals. For instance, if one statement designates an individual as an approver for all accounts, but another statement specifies that the same individual is not allowed to self-approve or to bypass the approval process for a particular account and permission set (by setting "allow_self_approval" and "approval_is_not_required" to `False`), then that individual will not be able to approve requests for that specific account, thereby enforcing a stricter control.
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ By default, a statement says what can be requested and who approves it, but not 
 - It is enforced at both request time and approval time, so an ineligible request can't be approved either.
 - If the requester cannot be resolved to an SSO user (or group memberships can't be fetched), statements restricted with `AllowedGroups` fail closed — they are treated as not available to that requester. Unrestricted statements are unaffected.
 - If statements match the request but the requester is not eligible for any of them, the request is denied with a "not allowed to request" message.
+- The Slack request dialogs only show what the requester is eligible for: groups, accounts, and permission sets covered solely by statements the requester can't use are hidden from the select lists. If nothing is available, the dialog shows a "not allowed to request access" message instead of the form. (Note: account and permission-set lists are filtered independently, so a specific ineligible account/permission-set *combination* may still be selectable — it is denied on submission.)
 
 Example — developers can request `ReadOnlyAccess` themselves, but only members of the infra group (or a specific user) can request `AdministratorAccess`:
 

--- a/slack_handler_lambda.tf
+++ b/slack_handler_lambda.tf
@@ -219,6 +219,7 @@ data "aws_iam_policy_document" "slack_handler" {
       "identitystore:ListGroups",
       "identitystore:DescribeGroup",
       "identitystore:ListGroupMemberships",
+      "identitystore:ListGroupMembershipsForMember",
       "identitystore:CreateGroupMembership",
     ]
     resources = ["*"]

--- a/src/access_control.py
+++ b/src/access_control.py
@@ -10,7 +10,7 @@ import s3
 import schedule
 import sso
 from entities import BaseModel
-from statement import GroupStatement, Statement, get_affected_group_statements, get_affected_statements
+from statement import GroupStatement, Statement, get_affected_group_statements, get_affected_statements, requester_allowed
 
 logger = config.get_logger("access_control")
 cfg = config.get_config()
@@ -28,6 +28,7 @@ class DecisionReason(Enum):
     SelfApproval = "SelfApproval"
     NoStatements = "NoStatements"
     NoApprovers = "NoApprovers"
+    RequesterNotAllowed = "RequesterNotAllowed"
 
 
 class AccessRequestDecision(BaseModel):
@@ -35,6 +36,64 @@ class AccessRequestDecision(BaseModel):
     reason: DecisionReason
     based_on_statements: FrozenSet[Statement] | FrozenSet[GroupStatement]
     approvers: FrozenSet[str] = frozenset()
+
+
+def requester_email_variants(requester_email: str) -> FrozenSet[str]:
+    """Lowercased requester address plus local-part + each ``secondary_fallback_email_domains`` entry.
+
+    Mirrors the fallback used by :func:`sso.get_user_principal_id_by_email`, so ``allowed_users``
+    matches whichever address variant an admin configured.
+    """
+    email = (requester_email or "").strip()
+    if not email:
+        return frozenset()
+    variants: set[str] = {email.lower()}
+    if "@" in email:
+        first_part, _ = email.split("@", 1)
+        for domain in cfg.secondary_fallback_email_domains or []:
+            variants.add((first_part + domain).lower())
+    return frozenset(variants)
+
+
+def get_requester_group_ids(requester_email: str) -> FrozenSet[str]:
+    """Resolve the SSO group IDs the requester belongs to.
+
+    Used to evaluate the optional ``allowed_groups`` requester restriction. Returns an empty
+    set if the requester can't be resolved to an SSO user — restricted statements then deny
+    (fail closed) while unrestricted statements are unaffected.
+    """
+    try:
+        sso_instance = sso.describe_sso_instance(sso_client, cfg.sso_instance_arn)
+        user_principal_id, _ = sso.get_user_principal_id_by_email(
+            identity_store_client=identitystore_client,
+            identity_store_id=sso_instance.identity_store_id,
+            email=requester_email,
+            cfg=cfg,
+        )
+        return sso.list_groups_for_user(sso_instance.identity_store_id, user_principal_id, identitystore_client)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not resolve requester group memberships; treating as no groups", extra={"error": str(e)})
+        return frozenset()
+
+
+def get_requester_group_ids_if_needed(
+    statements: FrozenSet[Statement] | FrozenSet[GroupStatement],
+    requester_email: str,
+) -> FrozenSet[str]:
+    """Resolve requester group memberships only when some statement restricts by ``allowed_groups``."""
+    if not any(statement.allowed_groups for statement in statements):
+        return frozenset()
+    return get_requester_group_ids(requester_email)
+
+
+def _filter_statements_for_requester(
+    statements: FrozenSet[Statement] | FrozenSet[GroupStatement],
+    requester_email: str,
+    requester_group_ids: FrozenSet[str],
+) -> FrozenSet[Statement] | FrozenSet[GroupStatement]:
+    """Drop statements the requester isn't eligible for, based on ``allowed_groups``/``allowed_users``."""
+    emails = requester_email_variants(requester_email)
+    return frozenset(st for st in statements if requester_allowed(st, emails, requester_group_ids))  # type: ignore # noqa: PGH003
 
 
 def determine_affected_statements(
@@ -55,14 +114,23 @@ def determine_affected_statements(
     raise TypeError("Statements contain mixed or unsupported types.")
 
 
-def make_decision_on_access_request(  # noqa: PLR0911
+def make_decision_on_access_request(  # noqa: PLR0911, PLR0913
     statements: FrozenSet[Statement] | FrozenSet[GroupStatement],
     requester_email: str,
     permission_set_name: str | None = None,
     account_id: str | None = None,
     group_id: str | None = None,
+    requester_group_ids: FrozenSet[str] = frozenset(),
 ) -> AccessRequestDecision:
     affected_statements = determine_affected_statements(statements, account_id, permission_set_name, group_id)
+    eligible_statements = _filter_statements_for_requester(affected_statements, requester_email, requester_group_ids)
+    if affected_statements and not eligible_statements:
+        return AccessRequestDecision(
+            grant=False,
+            reason=DecisionReason.RequesterNotAllowed,
+            based_on_statements=frozenset(),
+        )
+    affected_statements = eligible_statements
 
     decision_based_on_statements: set[Statement] | set[GroupStatement] = set()
     potential_approvers = set()
@@ -126,14 +194,16 @@ class ApproveRequestDecision(BaseModel):
 
 def make_decision_on_approve_request(  # noqa: PLR0913
     action: entities.ApproverAction,
-    statements: frozenset[Statement],
+    statements: frozenset[Statement] | frozenset[GroupStatement],
     approver_email: str,
     requester_email: str,
     permission_set_name: str | None = None,
     account_id: str | None = None,
     group_id: str | None = None,
+    requester_group_ids: FrozenSet[str] = frozenset(),
 ) -> ApproveRequestDecision:
     affected_statements = determine_affected_statements(statements, account_id, permission_set_name, group_id)
+    affected_statements = _filter_statements_for_requester(affected_statements, requester_email, requester_group_ids)
 
     for statement in affected_statements:
         if approver_email in statement.approvers:

--- a/src/access_control.py
+++ b/src/access_control.py
@@ -96,6 +96,70 @@ def _filter_statements_for_requester(
     return frozenset(st for st in statements if requester_allowed(st, emails, requester_group_ids))  # type: ignore # noqa: PGH003
 
 
+def eligible_group_ids(
+    statements: FrozenSet[GroupStatement],
+    requester_email: str,
+    requester_group_ids: FrozenSet[str],
+) -> FrozenSet[str]:
+    """Group IDs the requester may request, per each statement's ``allowed_groups``/``allowed_users``.
+
+    Used to filter the request modal so a requester only sees groups they can actually request.
+    """
+    emails = requester_email_variants(requester_email)
+    return frozenset(
+        group_id for statement in statements if requester_allowed(statement, emails, requester_group_ids) for group_id in statement.resource
+    )
+
+
+def eligible_accounts_and_permission_sets(
+    statements: FrozenSet[Statement],
+    requester_email: str,
+    requester_group_ids: FrozenSet[str],
+) -> tuple[FrozenSet[str] | None, FrozenSet[str] | None]:
+    """Account IDs and permission-set names the requester may request, per ``allowed_groups``/``allowed_users``.
+
+    ``None`` for either element means "unrestricted" — a ``*`` wildcard appeared in an eligible
+    statement, so all accounts / permission sets should be shown.
+    """
+    emails = requester_email_variants(requester_email)
+    accounts: set[str] = set()
+    permission_sets: set[str] = set()
+    accounts_wildcard = False
+    permission_sets_wildcard = False
+    for statement in statements:
+        if not requester_allowed(statement, emails, requester_group_ids):
+            continue
+        if "*" in statement.permission_set:
+            permission_sets_wildcard = True
+        else:
+            permission_sets.update(statement.permission_set)
+        if statement.resource_type == "Account":
+            if "*" in statement.resource:
+                accounts_wildcard = True
+            else:
+                accounts.update(statement.resource)
+    return (
+        None if accounts_wildcard else frozenset(accounts),
+        None if permission_sets_wildcard else frozenset(permission_sets),
+    )
+
+
+def filter_account_request_options(  # noqa: PLR0913
+    accounts: list[entities.aws.Account],
+    permission_sets: list[entities.aws.PermissionSet],
+    statements: FrozenSet[Statement],
+    requester_email: str,
+    requester_group_ids: FrozenSet[str],
+) -> tuple[list[entities.aws.Account], list[entities.aws.PermissionSet]]:
+    """Filter the request modal's account/permission-set options to what the requester may request."""
+    allowed_accounts, allowed_permission_sets = eligible_accounts_and_permission_sets(statements, requester_email, requester_group_ids)
+    if allowed_accounts is not None:
+        accounts = [account for account in accounts if account.id in allowed_accounts]
+    if allowed_permission_sets is not None:
+        permission_sets = [permission_set for permission_set in permission_sets if permission_set.name in allowed_permission_sets]
+    return accounts, permission_sets
+
+
 def determine_affected_statements(
     statements: FrozenSet[Statement] | FrozenSet[GroupStatement],
     account_id: str | None = None,

--- a/src/config.py
+++ b/src/config.py
@@ -82,6 +82,8 @@ def parse_statement(_dict: dict) -> Statement:
             "resource_type": _dict.get("ResourceType"),
             "approval_is_not_required": _dict.get("ApprovalIsNotRequired"),
             "allow_self_approval": _dict.get("AllowSelfApproval"),
+            "allowed_groups": to_set_if_list_or_str(_dict.get("AllowedGroups", set())),
+            "allowed_users": to_set_if_list_or_str(_dict.get("AllowedUsers", set())),
         }
     )
 
@@ -98,6 +100,8 @@ def parse_group_statement(_dict: dict) -> GroupStatement:
             "approvers": to_set_if_list_or_str(_dict.get("Approvers", set())),
             "approval_is_not_required": _dict.get("ApprovalIsNotRequired"),
             "allow_self_approval": _dict.get("AllowSelfApproval"),
+            "allowed_groups": to_set_if_list_or_str(_dict.get("AllowedGroups", set())),
+            "allowed_users": to_set_if_list_or_str(_dict.get("AllowedUsers", set())),
         }
     )
 

--- a/src/group.py
+++ b/src/group.py
@@ -28,7 +28,7 @@ sso_instance = sso.describe_sso_instance(sso_client, cfg.sso_instance_arn)
 identity_store_id = sso_instance.identity_store_id
 
 
-def _group_access_decision_messages(
+def _group_access_decision_messages(  # noqa: PLR0911
     client: WebClient,
     decision: access_control.AccessRequestDecision,
 ) -> tuple[str, str, str]:
@@ -87,6 +87,12 @@ def _group_access_decision_messages(
                 "There are no statements for this Group.",
                 cfg.bad_result_emoji,
             )
+        case access_control.DecisionReason.RequesterNotAllowed:
+            return (
+                "Requester is not allowed to request access to this Group.",
+                "You are not allowed to request access to this Group.",
+                cfg.bad_result_emoji,
+            )
 
 
 @handle_errors
@@ -107,6 +113,7 @@ def handle_request_for_group_access_submittion(
         cfg.group_statements,
         requester_email=requester.email,
         group_id=request.group_id,
+        requester_group_ids=access_control.get_requester_group_ids_if_needed(cfg.group_statements, requester.email),
     )
 
     show_buttons = bool(decision.approvers)
@@ -250,6 +257,7 @@ def handle_group_button_click(body: dict, client: WebClient, context: BoltContex
         group_id=payload.request.group_id,
         approver_email=approver.email,
         requester_email=requester.email,
+        requester_group_ids=access_control.get_requester_group_ids_if_needed(cfg.group_statements, requester.email),
     )
 
     logger.info("Decision on request was made", extra={"decision": decision.dict()})

--- a/src/main.py
+++ b/src/main.py
@@ -255,6 +255,7 @@ def handle_button_click(body: dict, client: WebClient, context: BoltContext) -> 
         permission_set_name=payload.request.permission_set_name,
         approver_email=approver.email,
         requester_email=requester.email,
+        requester_group_ids=access_control.get_requester_group_ids_if_needed(cfg.statements, requester.email),
     )
     logger.info("Decision on request was made", extra={"decision": decision.dict()})
 
@@ -334,6 +335,7 @@ def handle_request_for_access_submittion(  # noqa: PLR0915, PLR0912
         account_id=request.account_id,
         permission_set_name=request.permission_set_name,
         requester_email=requester.email,
+        requester_group_ids=access_control.get_requester_group_ids_if_needed(cfg.statements, requester.email),
     )
     logger.info("Decision on request was made", extra={"decision": decision.dict()})
 
@@ -416,6 +418,10 @@ def handle_request_for_access_submittion(  # noqa: PLR0915, PLR0912
         case access_control.DecisionReason.NoStatements:
             text = "There are no statements for this Permission Set & Account."
             dm_text = "There are no statements for this Permission Set & Account."
+            color_coding_emoji = cfg.bad_result_emoji
+        case access_control.DecisionReason.RequesterNotAllowed:
+            text = f"<@{requester.id}> is not allowed to request access to this Permission Set & Account."
+            dm_text = "You are not allowed to request access to this Permission Set & Account."
             color_coding_emoji = cfg.bad_result_emoji
 
     is_user_in_channel = slack_helpers.check_if_user_is_in_channel(client, cfg.slack_channel_id, requester.id)

--- a/src/main.py
+++ b/src/main.py
@@ -118,6 +118,21 @@ def load_select_options_for_group_access_request(client: WebClient, body: dict) 
     groups = sso.get_groups_from_config(sso_instance.identity_store_id, identity_store_client, cfg)
 
     user_id = body.get("user", {}).get("id")
+
+    # Only show groups the requester is eligible to request (AllowedGroups/AllowedUsers restrictions)
+    requester = slack_helpers.get_user(client, id=user_id)
+    requester_group_ids = access_control.get_requester_group_ids_if_needed(cfg.group_statements, requester.email)
+    eligible_group_ids = access_control.eligible_group_ids(cfg.group_statements, requester.email, requester_group_ids)
+    groups = [group for group in groups if group.id in eligible_group_ids]
+
+    if groups:
+        view = slack_helpers.RequestForGroupAccessView.update_with_groups(groups=groups)
+    else:
+        logger.info("Requester is not eligible for any group statement, showing empty state", extra={"requester_email": requester.email})
+        view = slack_helpers.RequestForGroupAccessView.build_no_available_options_view(
+            "You are not allowed to request access to any SSO group. Please contact your administrator if you believe this is a mistake."
+        )
+
     callback_id = slack_helpers.RequestForGroupAccessView.CALLBACK_ID
     view_key = f"{user_id}:{callback_id}"
 
@@ -130,11 +145,9 @@ def load_select_options_for_group_access_request(client: WebClient, body: dict) 
         )
         # Fallback: open a new view with the data already loaded
         trigger_id = body["trigger_id"]
-        view = slack_helpers.RequestForGroupAccessView.update_with_groups(groups=groups)
         return client.views_open(trigger_id=trigger_id, view=view)
 
     logger.debug(f"Updating view with view_id from key: {view_key}")
-    view = slack_helpers.RequestForGroupAccessView.update_with_groups(groups=groups)
     return client.views_update(view_id=view_id, view=view)
 
 
@@ -146,6 +159,29 @@ def load_select_options_for_account_access_request(client: WebClient, body: dict
     permission_sets = sso.get_permission_sets_from_config_with_cache(sso_client=sso_client, s3_client=s3_client, cfg=cfg)
 
     user_id = body.get("user", {}).get("id")
+
+    # Only show accounts/permission sets the requester is eligible to request (AllowedGroups/AllowedUsers restrictions)
+    requester = slack_helpers.get_user(client, id=user_id)
+    requester_group_ids = access_control.get_requester_group_ids_if_needed(cfg.statements, requester.email)
+    accounts, permission_sets = access_control.filter_account_request_options(
+        accounts=accounts,
+        permission_sets=permission_sets,
+        statements=cfg.statements,
+        requester_email=requester.email,
+        requester_group_ids=requester_group_ids,
+    )
+
+    if accounts and permission_sets:
+        view = slack_helpers.RequestForAccessView.update_with_accounts_and_permission_sets(
+            accounts=accounts, permission_sets=permission_sets
+        )
+    else:
+        logger.info("Requester is not eligible for any statement, showing empty state", extra={"requester_email": requester.email})
+        view = slack_helpers.RequestForAccessView.build_no_available_options_view(
+            "You are not allowed to request access to any account or permission set. "
+            "Please contact your administrator if you believe this is a mistake."
+        )
+
     callback_id = slack_helpers.RequestForAccessView.CALLBACK_ID
     view_key = f"{user_id}:{callback_id}"
 
@@ -158,13 +194,9 @@ def load_select_options_for_account_access_request(client: WebClient, body: dict
         )
         # Fallback: open a new view with the data already loaded
         trigger_id = body["trigger_id"]
-        view = slack_helpers.RequestForAccessView.update_with_accounts_and_permission_sets(
-            accounts=accounts, permission_sets=permission_sets
-        )
         return client.views_open(trigger_id=trigger_id, view=view)
 
     logger.debug(f"Updating view with view_id from key: {view_key}")
-    view = slack_helpers.RequestForAccessView.update_with_accounts_and_permission_sets(accounts=accounts, permission_sets=permission_sets)
     return client.views_update(view_id=view_id, view=view)
 
 

--- a/src/slack_helpers.py
+++ b/src/slack_helpers.py
@@ -143,6 +143,17 @@ class RequestForAccessView:
         )
 
     @classmethod
+    def build_no_available_options_view(cls, message: str) -> View:
+        # No submit button: there is nothing the user could request.
+        return View(
+            type="modal",
+            callback_id=cls.CALLBACK_ID,
+            close=PlainTextObject(text="Close"),
+            title=PlainTextObject(text="Get AWS access"),
+            blocks=[SectionBlock(text=MarkdownTextObject(text=message))],
+        )
+
+    @classmethod
     def update_with_accounts_and_permission_sets(
         cls, accounts: list[entities.aws.Account], permission_sets: list[entities.aws.PermissionSet]
     ) -> View:
@@ -557,6 +568,17 @@ class RequestForGroupAccessView:
                     ),
                 ),
             ],
+        )
+
+    @classmethod
+    def build_no_available_options_view(cls, message: str) -> View:  # noqa: ANN102
+        # No submit button: there is nothing the user could request.
+        return View(
+            type="modal",
+            callback_id=cls.CALLBACK_ID,
+            close=PlainTextObject(text="Close"),
+            title=PlainTextObject(text="Get AWS access"),
+            blocks=[SectionBlock(text=MarkdownTextObject(text=message))],
         )
 
     @classmethod

--- a/src/sso.py
+++ b/src/sso.py
@@ -566,6 +566,18 @@ def list_group_memberships(
     return group_memberships
 
 
+def list_groups_for_user(identity_store_id: str, sso_user_id: str, identity_store_client: IdentityStoreClient) -> frozenset[str]:
+    """Return the set of SSO group IDs the given user is a member of."""
+    paginator = identity_store_client.get_paginator("list_group_memberships_for_member")
+    group_ids: set[str] = set()
+    for page in paginator.paginate(IdentityStoreId=identity_store_id, MemberId={"UserId": sso_user_id}):
+        for membership in page["GroupMemberships"]:
+            if group_id := membership.get("GroupId"):
+                group_ids.add(group_id)
+    logger.debug("Groups for user", extra={"sso_user_id": sso_user_id, "group_ids": group_ids})
+    return frozenset(group_ids)
+
+
 def is_user_in_group(identity_store_id: str, group_id: str, sso_user_id: str, identity_store_client: IdentityStoreClient) -> str | None:
     group_memberships = list_group_memberships(identity_store_id, group_id, identity_store_client)
     for member in group_memberships:

--- a/src/statement.py
+++ b/src/statement.py
@@ -16,6 +16,29 @@ AWSAccountId = Annotated[str, Field(pattern=r"^\d{12}$")]
 AWSOUName = Annotated[str, Field(pattern=r"^[\s\S]{1,128}$")]
 PermissionSetName = Annotated[str, Field(pattern=r"^[\w+=,.@-]{1,32}$")]
 WildCard = Annotated[str, Field(pattern=r"^\*$")]
+AWSSSOGroupID = Annotated[
+    str, Field(pattern=r"^([0-9a-f]{10}-)?[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$")
+]
+
+
+def requester_allowed(
+    statement: "BaseStatement | GroupStatement",
+    requester_emails: FrozenSet[str],
+    requester_group_ids: FrozenSet[str],
+) -> bool:
+    """Whether a requester may use a statement.
+
+    Empty ``allowed_groups`` and ``allowed_users`` means no restriction (backward-compatible
+    default). Otherwise the requester must be a member of at least one of the listed SSO groups
+    or be listed by email in ``allowed_users``. ``requester_emails`` holds the requester's email
+    variants (e.g. with secondary fallback domains applied), matched case-insensitively.
+    """
+    if not statement.allowed_groups and not statement.allowed_users:
+        return True
+    allowed_users = {user.lower() for user in statement.allowed_users}
+    if any(email.lower() in allowed_users for email in requester_emails):
+        return True
+    return bool(statement.allowed_groups & requester_group_ids)
 
 
 class BaseStatement(BaseModel):
@@ -24,6 +47,12 @@ class BaseStatement(BaseModel):
     allow_self_approval: bool | None = None
     approval_is_not_required: bool | None = None
     approvers: FrozenSet[EmailStr] = Field(default_factory=frozenset)
+    #: Optional requester restriction: SSO group IDs whose members may request this statement.
+    #: Empty (together with allowed_users) = unrestricted.
+    allowed_groups: FrozenSet[AWSSSOGroupID] = Field(default_factory=frozenset)
+    #: Optional requester restriction: emails of users who may request this statement.
+    #: Empty (together with allowed_groups) = unrestricted.
+    allowed_users: FrozenSet[EmailStr] = Field(default_factory=frozenset)
 
 
 class Statement(BaseStatement):
@@ -45,16 +74,17 @@ class OUStatement(BaseStatement):
     resource: FrozenSet[Union[AWSOUName, WildCard]]
 
 
-AWSSSOGroupID = Annotated[
-    str, Field(pattern=r"^([0-9a-f]{10}-)?[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$")
-]
-
-
 class GroupStatement(BaseModel):
     resource: FrozenSet[AWSSSOGroupID]
     allow_self_approval: bool | None = None
     approval_is_not_required: bool | None = None
     approvers: FrozenSet[EmailStr] = Field(default_factory=frozenset)
+    #: Optional requester restriction: SSO group IDs whose members may request this statement.
+    #: Empty (together with allowed_users) = unrestricted.
+    allowed_groups: FrozenSet[AWSSSOGroupID] = Field(default_factory=frozenset)
+    #: Optional requester restriction: emails of users who may request this statement.
+    #: Empty (together with allowed_groups) = unrestricted.
+    allowed_users: FrozenSet[EmailStr] = Field(default_factory=frozenset)
 
     def affects(self, group_id: str) -> bool:  # noqa: ANN101
         return group_id in self.resource

--- a/src/tests/test_requester_restrictions.py
+++ b/src/tests/test_requester_restrictions.py
@@ -1,0 +1,381 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+import access_control
+import config
+import entities
+import sso
+from access_control import (
+    DecisionReason,
+    make_decision_on_access_request,
+    make_decision_on_approve_request,
+)
+from statement import GroupStatement, Statement, requester_allowed
+
+# ruff: noqa: ANN201, ANN001
+
+GROUP_A = "11111111-2222-3333-4444-555555555555"
+GROUP_B = "66666666-7777-8888-9999-000000000000"
+
+
+def account_statement(**overrides) -> Statement:
+    return Statement.model_validate(
+        {
+            "resource_type": "Account",
+            "resource": ["111111111111"],
+            "permission_set": ["AdministratorAccess"],
+            "approvers": ["approver@test.com"],
+        }
+        | overrides
+    )
+
+
+def group_statement(**overrides) -> GroupStatement:
+    return GroupStatement.model_validate(
+        {
+            "resource": [GROUP_A],
+            "approvers": ["approver@test.com"],
+        }
+        | overrides
+    )
+
+
+class TestRequesterAllowed:
+    def test_unrestricted_statement_allows_anyone(self):
+        st = account_statement()
+        assert requester_allowed(st, frozenset(["anybody@test.com"]), frozenset()) is True
+
+    def test_allowed_users_match(self):
+        st = Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["dev@test.com"]})
+        assert requester_allowed(st, frozenset(["dev@test.com"]), frozenset()) is True
+
+    def test_allowed_users_match_is_case_insensitive(self):
+        st = Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["Dev@Test.com"]})
+        assert requester_allowed(st, frozenset(["dev@test.com"]), frozenset()) is True
+
+    def test_allowed_users_no_match(self):
+        st = Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["dev@test.com"]})
+        assert requester_allowed(st, frozenset(["other@test.com"]), frozenset()) is False
+
+    def test_allowed_groups_match(self):
+        st = Statement.model_validate({**account_statement().model_dump(), "allowed_groups": [GROUP_A]})
+        assert requester_allowed(st, frozenset(["dev@test.com"]), frozenset([GROUP_A, GROUP_B])) is True
+
+    def test_allowed_groups_no_match(self):
+        st = Statement.model_validate({**account_statement().model_dump(), "allowed_groups": [GROUP_A]})
+        assert requester_allowed(st, frozenset(["dev@test.com"]), frozenset([GROUP_B])) is False
+
+    def test_either_users_or_groups_restriction_suffices(self):
+        st = Statement.model_validate({**account_statement().model_dump(), "allowed_groups": [GROUP_A], "allowed_users": ["dev@test.com"]})
+        assert requester_allowed(st, frozenset(["dev@test.com"]), frozenset()) is True
+        assert requester_allowed(st, frozenset(["other@test.com"]), frozenset([GROUP_A])) is True
+        assert requester_allowed(st, frozenset(["other@test.com"]), frozenset([GROUP_B])) is False
+
+    def test_group_statement_restrictions(self):
+        st = GroupStatement.model_validate({**group_statement().model_dump(), "allowed_groups": [GROUP_B]})
+        assert requester_allowed(st, frozenset(["dev@test.com"]), frozenset([GROUP_B])) is True
+        assert requester_allowed(st, frozenset(["dev@test.com"]), frozenset()) is False
+
+
+class TestConfigParsing:
+    def test_parse_statement_with_restrictions(self):
+        st = config.parse_statement(
+            {
+                "ResourceType": "Account",
+                "Resource": ["111111111111"],
+                "PermissionSet": "AdministratorAccess",
+                "Approvers": "approver@test.com",
+                "AllowedGroups": [GROUP_A],
+                "AllowedUsers": ["dev@test.com", "dev2@test.com"],
+            }
+        )
+        assert st.allowed_groups == frozenset([GROUP_A])
+        assert st.allowed_users == frozenset(["dev@test.com", "dev2@test.com"])
+
+    def test_parse_statement_accepts_single_string_values(self):
+        st = config.parse_statement(
+            {
+                "ResourceType": "Account",
+                "Resource": ["111111111111"],
+                "PermissionSet": "AdministratorAccess",
+                "AllowedGroups": GROUP_A,
+                "AllowedUsers": "dev@test.com",
+            }
+        )
+        assert st.allowed_groups == frozenset([GROUP_A])
+        assert st.allowed_users == frozenset(["dev@test.com"])
+
+    def test_parse_statement_defaults_to_unrestricted(self):
+        st = config.parse_statement(
+            {
+                "ResourceType": "Account",
+                "Resource": ["111111111111"],
+                "PermissionSet": "AdministratorAccess",
+            }
+        )
+        assert st.allowed_groups == frozenset()
+        assert st.allowed_users == frozenset()
+
+    def test_parse_group_statement_with_restrictions(self):
+        st = config.parse_group_statement(
+            {
+                "Resource": [GROUP_A],
+                "Approvers": "approver@test.com",
+                "AllowedGroups": [GROUP_B],
+                "AllowedUsers": "dev@test.com",
+            }
+        )
+        assert st.allowed_groups == frozenset([GROUP_B])
+        assert st.allowed_users == frozenset(["dev@test.com"])
+
+    def test_parse_group_statement_defaults_to_unrestricted(self):
+        st = config.parse_group_statement({"Resource": [GROUP_A]})
+        assert st.allowed_groups == frozenset()
+        assert st.allowed_users == frozenset()
+
+    def test_parse_statement_rejects_invalid_allowed_group_id(self):
+        with pytest.raises(ValidationError):
+            config.parse_statement(
+                {
+                    "ResourceType": "Account",
+                    "Resource": ["111111111111"],
+                    "PermissionSet": "AdministratorAccess",
+                    "AllowedGroups": ["not-a-group-id"],
+                }
+            )
+
+    def test_parse_statement_rejects_invalid_allowed_user_email(self):
+        with pytest.raises(ValidationError):
+            config.parse_statement(
+                {
+                    "ResourceType": "Account",
+                    "Resource": ["111111111111"],
+                    "PermissionSet": "AdministratorAccess",
+                    "AllowedUsers": ["not-an-email"],
+                }
+            )
+
+
+class TestAccessRequestDecision:
+    def test_requester_in_allowed_group_requires_approval(self):
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_groups": [GROUP_A]})])
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="dev@test.com",
+            account_id="111111111111",
+            permission_set_name="AdministratorAccess",
+            requester_group_ids=frozenset([GROUP_A]),
+        )
+        assert decision.grant is False
+        assert decision.reason == DecisionReason.RequiresApproval
+        assert decision.approvers == frozenset(["approver@test.com"])
+
+    def test_requester_not_in_allowed_group_is_denied(self):
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_groups": [GROUP_A]})])
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="dev@test.com",
+            account_id="111111111111",
+            permission_set_name="AdministratorAccess",
+            requester_group_ids=frozenset([GROUP_B]),
+        )
+        assert decision.grant is False
+        assert decision.reason == DecisionReason.RequesterNotAllowed
+        assert decision.based_on_statements == frozenset()
+
+    def test_requester_in_allowed_users_requires_approval(self):
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["dev@test.com"]})])
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="dev@test.com",
+            account_id="111111111111",
+            permission_set_name="AdministratorAccess",
+        )
+        assert decision.reason == DecisionReason.RequiresApproval
+
+    def test_requester_not_in_allowed_users_is_denied(self):
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["dev@test.com"]})])
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="other@test.com",
+            account_id="111111111111",
+            permission_set_name="AdministratorAccess",
+        )
+        assert decision.reason == DecisionReason.RequesterNotAllowed
+
+    def test_restriction_blocks_even_when_approval_not_required(self):
+        statements = frozenset(
+            [
+                Statement.model_validate(
+                    {
+                        **account_statement().model_dump(),
+                        "approval_is_not_required": True,
+                        "allowed_users": ["dev@test.com"],
+                    }
+                )
+            ]
+        )
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="other@test.com",
+            account_id="111111111111",
+            permission_set_name="AdministratorAccess",
+        )
+        assert decision.grant is False
+        assert decision.reason == DecisionReason.RequesterNotAllowed
+
+    def test_unrestricted_statement_still_applies_when_restricted_one_is_filtered(self):
+        restricted = Statement.model_validate(
+            {**account_statement().model_dump(), "approvers": ["admin@test.com"], "allowed_groups": [GROUP_A]}
+        )
+        unrestricted = account_statement()
+        decision = make_decision_on_access_request(
+            frozenset([restricted, unrestricted]),
+            requester_email="dev@test.com",
+            account_id="111111111111",
+            permission_set_name="AdministratorAccess",
+            requester_group_ids=frozenset(),
+        )
+        assert decision.reason == DecisionReason.RequiresApproval
+        assert decision.based_on_statements == frozenset([unrestricted])
+        assert decision.approvers == frozenset(["approver@test.com"])
+
+    def test_no_statements_still_reported_when_nothing_affects_request(self):
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["dev@test.com"]})])
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="dev@test.com",
+            account_id="222222222222",
+            permission_set_name="AdministratorAccess",
+        )
+        assert decision.reason == DecisionReason.NoStatements
+
+    def test_group_request_requester_in_allowed_group(self):
+        statements = frozenset([GroupStatement.model_validate({**group_statement().model_dump(), "allowed_groups": [GROUP_B]})])
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="dev@test.com",
+            group_id=GROUP_A,
+            requester_group_ids=frozenset([GROUP_B]),
+        )
+        assert decision.reason == DecisionReason.RequiresApproval
+
+    def test_group_request_requester_not_allowed(self):
+        statements = frozenset([GroupStatement.model_validate({**group_statement().model_dump(), "allowed_groups": [GROUP_B]})])
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="dev@test.com",
+            group_id=GROUP_A,
+            requester_group_ids=frozenset(),
+        )
+        assert decision.reason == DecisionReason.RequesterNotAllowed
+
+    def test_group_request_requester_in_allowed_users(self):
+        statements = frozenset([GroupStatement.model_validate({**group_statement().model_dump(), "allowed_users": ["dev@test.com"]})])
+        decision = make_decision_on_access_request(
+            statements,
+            requester_email="dev@test.com",
+            group_id=GROUP_A,
+        )
+        assert decision.reason == DecisionReason.RequiresApproval
+
+
+class TestApproveRequestDecision:
+    def test_approver_cannot_approve_for_ineligible_requester(self):
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["dev@test.com"]})])
+        decision = make_decision_on_approve_request(
+            action=entities.ApproverAction.Approve,
+            statements=statements,
+            approver_email="approver@test.com",
+            requester_email="other@test.com",
+            account_id="111111111111",
+            permission_set_name="AdministratorAccess",
+        )
+        assert decision.permit is False
+        assert decision.grant is False
+
+    def test_approver_can_approve_for_eligible_requester(self):
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["dev@test.com"]})])
+        decision = make_decision_on_approve_request(
+            action=entities.ApproverAction.Approve,
+            statements=statements,
+            approver_email="approver@test.com",
+            requester_email="dev@test.com",
+            account_id="111111111111",
+            permission_set_name="AdministratorAccess",
+        )
+        assert decision.permit is True
+        assert decision.grant is True
+
+    def test_group_approval_denied_for_requester_outside_allowed_group(self):
+        statements = frozenset([GroupStatement.model_validate({**group_statement().model_dump(), "allowed_groups": [GROUP_B]})])
+        decision = make_decision_on_approve_request(
+            action=entities.ApproverAction.Approve,
+            statements=statements,  # type: ignore # noqa: PGH003
+            approver_email="approver@test.com",
+            requester_email="dev@test.com",
+            group_id=GROUP_A,
+            requester_group_ids=frozenset(),
+        )
+        assert decision.permit is False
+
+    def test_group_approval_permitted_for_requester_in_allowed_group(self):
+        statements = frozenset([GroupStatement.model_validate({**group_statement().model_dump(), "allowed_groups": [GROUP_B]})])
+        decision = make_decision_on_approve_request(
+            action=entities.ApproverAction.Approve,
+            statements=statements,  # type: ignore # noqa: PGH003
+            approver_email="approver@test.com",
+            requester_email="dev@test.com",
+            group_id=GROUP_A,
+            requester_group_ids=frozenset([GROUP_B]),
+        )
+        assert decision.permit is True
+
+
+class TestRequesterGroupResolution:
+    def test_email_variants_include_secondary_fallback_domains(self):
+        # conftest sets secondary_fallback_email_domains to ["domen.com"]
+        variants = access_control.requester_email_variants("Dev@Test.com")
+        assert variants == frozenset(["dev@test.com", "devdomen.com"])
+
+    def test_email_variants_empty_email(self):
+        assert access_control.requester_email_variants("") == frozenset()
+
+    def test_group_lookup_skipped_when_no_statement_restricts_by_group(self, monkeypatch):
+        def fail(*_args, **_kwargs):  # noqa: ANN002, ANN003
+            raise AssertionError("get_requester_group_ids should not be called")
+
+        monkeypatch.setattr(access_control, "get_requester_group_ids", fail)
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_users": ["dev@test.com"]})])
+        assert access_control.get_requester_group_ids_if_needed(statements, "dev@test.com") == frozenset()
+
+    def test_group_lookup_performed_when_statement_restricts_by_group(self, monkeypatch):
+        monkeypatch.setattr(access_control, "get_requester_group_ids", lambda _email: frozenset([GROUP_A]))
+        statements = frozenset([Statement.model_validate({**account_statement().model_dump(), "allowed_groups": [GROUP_A]})])
+        assert access_control.get_requester_group_ids_if_needed(statements, "dev@test.com") == frozenset([GROUP_A])
+
+    def test_get_requester_group_ids_fails_closed(self, monkeypatch):
+        def boom(*_args, **_kwargs):  # noqa: ANN002, ANN003
+            raise RuntimeError("SSO unavailable")
+
+        monkeypatch.setattr(access_control.sso, "describe_sso_instance", boom)
+        assert access_control.get_requester_group_ids("dev@test.com") == frozenset()
+
+
+class TestListGroupsForUser:
+    def test_collects_group_ids_across_pages(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {"GroupMemberships": [{"GroupId": GROUP_A}, {"GroupId": GROUP_B}]},
+            {"GroupMemberships": [{"GroupId": GROUP_B}, {"MembershipId": "no-group-id"}]},
+        ]
+
+        result = sso.list_groups_for_user("d-1234567890", "user-id", client)
+
+        assert result == frozenset([GROUP_A, GROUP_B])
+        client.get_paginator.assert_called_once_with("list_group_memberships_for_member")
+        paginator.paginate.assert_called_once_with(IdentityStoreId="d-1234567890", MemberId={"UserId": "user-id"})

--- a/src/tests/test_requester_restrictions.py
+++ b/src/tests/test_requester_restrictions.py
@@ -379,3 +379,98 @@ class TestListGroupsForUser:
         assert result == frozenset([GROUP_A, GROUP_B])
         client.get_paginator.assert_called_once_with("list_group_memberships_for_member")
         paginator.paginate.assert_called_once_with(IdentityStoreId="d-1234567890", MemberId={"UserId": "user-id"})
+
+
+class TestModalOptionFiltering:
+    """Filtering of the Slack request modal's options to what the requester may request."""
+
+    def test_eligible_group_ids_unrestricted_returns_all(self):
+        statements = frozenset([group_statement(), group_statement(resource=[GROUP_B])])
+        assert access_control.eligible_group_ids(statements, "dev@test.com", frozenset()) == frozenset([GROUP_A, GROUP_B])
+
+    def test_eligible_group_ids_hides_restricted_groups(self):
+        restricted = GroupStatement.model_validate(
+            {**group_statement(resource=[GROUP_B]).model_dump(), "allowed_users": ["oncall@test.com"]}
+        )
+        statements = frozenset([group_statement(), restricted])
+        assert access_control.eligible_group_ids(statements, "dev@test.com", frozenset()) == frozenset([GROUP_A])
+        assert access_control.eligible_group_ids(statements, "oncall@test.com", frozenset()) == frozenset([GROUP_A, GROUP_B])
+
+    def test_eligible_group_ids_by_group_membership(self):
+        restricted = GroupStatement.model_validate({**group_statement(resource=[GROUP_B]).model_dump(), "allowed_groups": [GROUP_A]})
+        statements = frozenset([restricted])
+        assert access_control.eligible_group_ids(statements, "dev@test.com", frozenset([GROUP_A])) == frozenset([GROUP_B])
+        assert access_control.eligible_group_ids(statements, "dev@test.com", frozenset()) == frozenset()
+
+    def test_eligible_accounts_and_permission_sets_wildcard_means_unrestricted(self):
+        statements = frozenset([account_statement(resource=["*"], permission_set=["*"])])
+        accounts, permission_sets = access_control.eligible_accounts_and_permission_sets(statements, "dev@test.com", frozenset())
+        assert accounts is None
+        assert permission_sets is None
+
+    def test_eligible_accounts_and_permission_sets_ignores_ineligible_statements(self):
+        restricted = Statement.model_validate(
+            {
+                **account_statement(resource=["222222222222"], permission_set=["AdministratorAccess"]).model_dump(),
+                "allowed_users": ["oncall@test.com"],
+            }
+        )
+        unrestricted = account_statement(resource=["111111111111"], permission_set=["ReadOnlyAccess"])
+        statements = frozenset([restricted, unrestricted])
+
+        accounts, permission_sets = access_control.eligible_accounts_and_permission_sets(statements, "dev@test.com", frozenset())
+        assert accounts == frozenset(["111111111111"])
+        assert permission_sets == frozenset(["ReadOnlyAccess"])
+
+        accounts, permission_sets = access_control.eligible_accounts_and_permission_sets(statements, "oncall@test.com", frozenset())
+        assert accounts == frozenset(["111111111111", "222222222222"])
+        assert permission_sets == frozenset(["ReadOnlyAccess", "AdministratorAccess"])
+
+    def test_filter_account_request_options(self):
+        restricted = Statement.model_validate(
+            {
+                **account_statement(resource=["222222222222"], permission_set=["AdministratorAccess"]).model_dump(),
+                "allowed_users": ["oncall@test.com"],
+            }
+        )
+        unrestricted = account_statement(resource=["111111111111"], permission_set=["ReadOnlyAccess"])
+        statements = frozenset([restricted, unrestricted])
+        all_accounts = [
+            entities.aws.Account(id="111111111111", name="dev"),
+            entities.aws.Account(id="222222222222", name="prod"),
+        ]
+        all_permission_sets = [
+            entities.aws.PermissionSet(name="ReadOnlyAccess", arn="arn:ro", description=None),
+            entities.aws.PermissionSet(name="AdministratorAccess", arn="arn:admin", description=None),
+        ]
+
+        accounts, permission_sets = access_control.filter_account_request_options(
+            all_accounts, all_permission_sets, statements, "dev@test.com", frozenset()
+        )
+        assert [account.id for account in accounts] == ["111111111111"]
+        assert [permission_set.name for permission_set in permission_sets] == ["ReadOnlyAccess"]
+
+        accounts, permission_sets = access_control.filter_account_request_options(
+            all_accounts, all_permission_sets, statements, "oncall@test.com", frozenset()
+        )
+        assert [account.id for account in accounts] == ["111111111111", "222222222222"]
+        assert [permission_set.name for permission_set in permission_sets] == ["ReadOnlyAccess", "AdministratorAccess"]
+
+    def test_filter_account_request_options_wildcard_keeps_everything(self):
+        statements = frozenset([account_statement(resource=["*"], permission_set=["*"])])
+        all_accounts = [entities.aws.Account(id="111111111111", name="dev")]
+        all_permission_sets = [entities.aws.PermissionSet(name="ReadOnlyAccess", arn="arn:ro", description=None)]
+        accounts, permission_sets = access_control.filter_account_request_options(
+            all_accounts, all_permission_sets, statements, "dev@test.com", frozenset()
+        )
+        assert accounts == all_accounts
+        assert permission_sets == all_permission_sets
+
+    def test_no_available_options_views_have_no_submit_button(self):
+        import slack_helpers
+
+        for view_class in (slack_helpers.RequestForAccessView, slack_helpers.RequestForGroupAccessView):
+            view = view_class.build_no_available_options_view("You are not allowed to request access.")
+            assert view.submit is None
+            assert view.callback_id == view_class.CALLBACK_ID
+            assert "not allowed" in view.blocks[0].text.text

--- a/src/uv.lock
+++ b/src/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "sso-elevator"
-version = "3.0.0"
+version = "4.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3-stubs", extra = ["events", "identitystore", "organizations", "s3", "scheduler", "sso-admin"] },


### PR DESCRIPTION
Statements in both config and group_config now accept optional AllowedGroups (SSO group IDs) and AllowedUsers (emails) fields that restrict who may request access using that statement. Empty means unrestricted, so existing configs are unaffected; if either is set, the requester must match one of them.
- enforced at request time and approval time, including ApprovalIsNotRequired/AllowSelfApproval statements; new RequesterNotAllowed decision reason with Slack denial messages
- group membership resolved via ListGroupMembershipsForMember, skipped when no statement uses AllowedGroups; fails closed if the requester can't be resolved in SSO
- AllowedUsers matched case-insensitively incl. secondary fallback email domains
- grant identitystore:ListGroupMembershipsForMember to the slack handler lambda

This PR is extending functionality of https://github.com/fivexl/terraform-aws-sso-elevator/pull/163 as it seems like the original PR is abandoned. 