### PR TITLE
Remove temporary use_pre_created_image override in examples/complete

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,13 +42,6 @@ module "aws_sso_elevator" {
   approver_renotification_initial_wait_time  = 15
   approver_renotification_backoff_multiplier = 2
 
-  # Builds the Lambda image from source instead of pulling the published one.
-  # Needed for now because the published image predates the CLI feature in
-  # this PR — the default (true) will work again once a real module release
-  # ships with CLI support and ecr_repo_tag is bumped to match. Remove this
-  # override at that point.
-  use_pre_created_image = false
-
   # Off by default (see vars.tf) so upgrading an existing deployment doesn't
   # silently add this route; this example turns it on to actually demonstrate
   # the CLI feature end to end.


### PR DESCRIPTION
Small follow-up to #175 / release 4.4.0.

`examples/complete/main.tf` had a temporary `use_pre_created_image = false` override, needed only because the previously-published image (4.3.1) predated the CLI route. Now that 4.4.0 is released with `ecr_repo_tag`'s default bumped to match, the module's own default (`true`) works again, so this override is no longer necessary — it was already commented as "remove this override at that point."
