### PR TITLE
Fix #193: remove has_account_assignment defense-in-depth check

### DIFF
--- a/slack_handler_lambda.tf
+++ b/slack_handler_lambda.tf
@@ -195,19 +195,6 @@ data "aws_iam_policy_document" "slack_handler" {
     actions = [
       "sso:CreateAccountAssignment",
       "sso:DescribeAccountAssignmentCreationStatus",
-      # Read-only, granted for src/main.py's CLI defense-in-depth check
-      # (sso.has_account_assignment): iam:GetRole (below) only proves a CLI
-      # session's role is genuinely IAM Identity Center-provisioned, not
-      # that this specific user was ever actually assigned this permission
-      # set on this account -- this makes that check redundant rather than
-      # load-bearing, requiring a real account assignment before trusting a
-      # session. Deliberately ListAccountAssignments, not
-      # ListAccountAssignmentsForPrincipal: AWS documents the latter as
-      # callable only from the IAM Identity Center management account, and
-      # this module's own docs recommend deploying in the delegated SSO
-      # administrator account, where that call always fails with
-      # AccessDeniedException.
-      "sso:ListAccountAssignments"
     ]
     resources = [
       "arn:aws:sso:::instance/*",

--- a/src/main.py
+++ b/src/main.py
@@ -197,9 +197,8 @@ def handle_cli_access_request(event: dict) -> dict:  # noqa: PLR0911, PLR0912, P
         # exactly what the comment above says this strict match exists to
         # avoid on an authorization-relevant field.
         #
-        # Checked before the account/permission-set catalog lookups below
-        # (and before has_account_assignment further down), not after: those
-        # two lookups are themselves expensive -- organizations:ListAccounts
+        # Checked before the account/permission-set catalog lookups below,
+        # not after: those two lookups are themselves expensive -- organizations:ListAccounts
         # or sso:ListPermissionSets plus one sso:DescribePermissionSet per
         # entry, all behind a per-route throttle any SSO principal in the
         # org can drive at 1 rps sustained -- and a malformed duration is
@@ -273,35 +272,24 @@ def handle_cli_access_request(event: dict) -> dict:  # noqa: PLR0911, PLR0912, P
                 "headers": {"content-type": "application/json"},
                 "body": json.dumps({"message": "permission_set must be a permission set this deployment is configured for."}),
             }
-        permission_set_arn = real_permission_sets[permission_set_name].arn
-
-        # Defense-in-depth against round-1 finding #6 (session name not
-        # bound to any real SSO account assignment): iam:GetRole (inside
-        # extract_identity) proves role_name is genuinely IAM Identity
-        # Center-provisioned, but says nothing about whether this specific
-        # user was ever actually assigned this permission set on this
-        # account -- a session under a reserved-path role that's still
-        # technically valid but was orphaned (e.g. after this exact
-        # assignment was revoked) would otherwise still pass. Placed here,
-        # after catalog resolution, rather than right after identity
-        # verification: has_account_assignment needs the real
-        # permission_set_arn to query list_account_assignments (a
-        # per-account-and-permission-set call, not a principal-wide one --
-        # see its docstring for why), and that's only available once the
-        # caller's permission_set_name has already been resolved against
-        # the real catalog above.
-        try:
-            has_assignment = sso.has_account_assignment(sso_client, cfg.sso_instance_arn, identity_user_id, account_id, permission_set_arn)
-        except sso.TransientSSOError:
-            logger.warning("Transient AWS error while checking the account assignment; asking the caller to retry")
-            return _transient_aws_error_response()
-        if not has_assignment:
-            logger.warning(
-                "Rejected CLI request: verified identity has no SSO account assignment for this account/permission set",
-                extra={"user_id": identity_user_id, "account_id": account_id, "permission_set_arn": permission_set_arn},
-            )
-            return cli_auth.GENERIC_REJECTION
-
+        # No "does the caller already hold this exact assignment" check here
+        # -- issue #193: that defense-in-depth check (round-1 finding #6)
+        # required the requester to already have the specific account/
+        # permission-set pair they were requesting, which rejects every
+        # genuine elevation request by construction (the whole point of this
+        # tool is granting access the caller does not currently have). It
+        # only ever passed for a redundant re-request of a still-live grant
+        # SSO Elevator had itself just issued. Removed rather than rescoped:
+        # a correct principal-wide "do they have any real assignment
+        # anywhere" check needs sso-admin:ListAccountAssignmentsForPrincipal,
+        # which round-3 already established doesn't work from this module's
+        # own recommended delegated-admin deployment topology, and any
+        # per-account variant has the same "rejects legitimate first-time
+        # access" problem this one did. The identity is still verified by
+        # SigV4 + AWS_IAM, iam:GetRole's reserved-path check (round-1 #6's
+        # own conclusion: AWS itself blocks non-Identity-Center role
+        # creation there), the session name resolving to a real Identity
+        # Store user, and the email round-trip cross-check below.
         try:
             requester = slack_helpers.get_user_by_email(app.client, identity_email)
         except slack_sdk.errors.SlackApiError:

--- a/src/sso.py
+++ b/src/sso.py
@@ -275,15 +275,6 @@ def list_user_account_assignments(
     return account_assignments
 
 
-class TransientSSOError(Exception):
-    """Raised when an sso-admin call in this module fails for a reason that
-    says nothing about whether the thing being checked is actually true --
-    throttling, a 5xx, or a connectivity failure with no HTTP response at
-    all. Mirrors cli_auth.TransientIAMError's purpose for its own calls;
-    kept as a separate type here rather than imported from cli_auth, since
-    cli_auth imports this module and a reverse import would be circular."""
-
-
 def is_transient_aws_error(error: Exception) -> bool:
     """True for a botocore error that says nothing about whether the
     underlying request was valid -- throttling, a 5xx, or a connectivity
@@ -297,56 +288,6 @@ def is_transient_aws_error(error: Exception) -> bool:
         status = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
         return status >= 500  # noqa: PLR2004
     return isinstance(error, botocore.exceptions.BotoCoreError)
-
-
-def has_account_assignment(client: SSOAdminClient, instance_arn: str, principal_id: str, account_id: str, permission_set_arn: str) -> bool:
-    """Whether principal_id (a UserId) has a real SSO account assignment for
-    permission_set_arn on account_id -- used as a defense-in-depth check
-    that a verified CLI session actually corresponds to someone with a live
-    assignment, rather than e.g. a reserved-path role that's still valid but
-    was orphaned after this specific assignment was revoked.
-
-    Deliberately list_account_assignments (per account + permission set),
-    not list_account_assignments_for_principal: AWS documents the latter as
-    callable "only from the management account containing your
-    organization instance of IAM Identity Center... not valid for account
-    instances" -- and this module's own docs recommend deploying in the
-    delegated SSO administrator account, where every call would raise
-    AccessDeniedException. list_account_assignments has no such
-    restriction, at the cost of needing the specific permission_set_arn
-    already being requested rather than a principal-wide answer -- which is
-    exactly the pair the caller has resolved by the time this runs.
-
-    An AccessDeniedException here degrades to "skip the check" (logged, not
-    raised, returns True) rather than rejecting or 500ing: this is
-    defense-in-depth on top of the real, statement-based access control
-    downstream, and a misconfigured or unexpectedly-scoped IAM policy for
-    this one read-only call must never be able to take the whole CLI route
-    down. A throttle/5xx/connectivity failure is different -- it says
-    nothing about whether the assignment exists, so it's surfaced as
-    TransientSSOError for the caller to turn into a retryable response,
-    same shape as cli_auth's transient-vs-real distinction for its own
-    calls. Any other error is a genuine, unexpected failure and is left to
-    propagate."""
-    try:
-        paginator = client.get_paginator("list_account_assignments")
-        for page in paginator.paginate(InstanceArn=instance_arn, AccountId=account_id, PermissionSetArn=permission_set_arn):
-            for assignment in page.get("AccountAssignments", []):
-                if assignment.get("PrincipalType") == "USER" and assignment.get("PrincipalId") == principal_id:
-                    return True
-        return False
-    except botocore.exceptions.ClientError as e:
-        if e.response.get("Error", {}).get("Code", "") == "AccessDeniedException":
-            logger.warning(
-                "list_account_assignments was denied -- skipping the account-assignment check rather than blocking the route",
-                extra={"error": str(e)},
-            )
-            return True
-        if is_transient_aws_error(e):
-            raise TransientSSOError from e
-        raise
-    except botocore.exceptions.BotoCoreError as e:
-        raise TransientSSOError from e
 
 
 def parse_permission_set(td: type_defs.DescribePermissionSetResponseTypeDef) -> entities.aws.PermissionSet:

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -66,14 +66,6 @@ def main_module():
     uses the same "req@example.com" identity throughout; the mismatch case
     is exercised on its own, separately.
 
-    get_paginator dispatches by operation name (list_users vs.
-    list_account_assignments) since the shared client backs both calls --
-    a single flat paginate() stub can't serve both shapes at once.
-    list_account_assignments is stubbed to report one real assignment (for
-    the "u-req" identity every test below verifies), since
-    handle_cli_access_request now requires at least one before proceeding
-    -- the empty/no-assignment case is exercised on its own, separately.
-
     organizations.get_accounts_from_config_with_cache and
     sso.get_permission_sets_from_config_with_cache are patched to the fake
     catalog-lookup functions above, rather than left to hit the (mocked)
@@ -103,10 +95,6 @@ def main_module():
                             {"UserId": "u-req", "UserName": "req@example.com", "Emails": [{"Value": "req@example.com", "Primary": True}]}
                         ]
                     }
-                ]
-            elif operation_name == "list_account_assignments":
-                paginator.paginate.return_value = [
-                    {"AccountAssignments": [{"AccountId": "111111111111", "PrincipalId": "u-req", "PrincipalType": "USER"}]}
                 ]
             else:
                 paginator.paginate.return_value = []
@@ -245,74 +233,43 @@ def test_handle_cli_access_request_rejects_untrusted_arn(main_module):
     assert result == main_module.cli_auth.GENERIC_REJECTION
 
 
-def test_handle_cli_access_request_rejects_identity_with_no_account_assignment(main_module):
-    """Defense-in-depth against round-1 finding #6: iam:GetRole proves
-    role_name is genuinely IAM Identity Center-provisioned, but says nothing
-    about whether this specific user was ever actually assigned anything on
-    this account -- a session under a reserved-path role that's still
-    technically valid but was orphaned (e.g. after every permission set
-    assignment for this user was revoked) must still be rejected."""
+def test_handle_cli_access_request_succeeds_with_no_prior_account_assignment(main_module):
+    """Regression test for issue #193: a genuine elevation request -- the
+    requester currently has *no* SSO account assignment at all for the
+    account/permission-set being requested -- must reach process_access_request,
+    not be rejected. The now-removed has_account_assignment defense-in-depth
+    check required the requester to already hold the exact assignment being
+    requested, which rejected every real elevation request by construction
+    (the entire point of this tool is granting access the caller does not
+    currently have) and only ever passed for a redundant re-request of a
+    still-live grant SSO Elevator had itself just issued. Reproduced live
+    against a real 4.4.0 deployment before this fix: a genuinely
+    unprivileged account/permission-set pair came back 403 GENERIC_REJECTION
+    every time."""
     event = _cli_request_event(
-        body={"account": "111111111111", "permission_set": "Foo", "reason": "x", "duration": "1"},
-        user_arn="arn:aws:sts::111111111111:assumed-role/AWSReservedSSO_Foo/req@example.com",
+        body={"account": "111111111111", "permission_set": "FullOrgAdmin", "reason": "incident response", "duration": "15"},
+        user_arn="arn:aws:sts::111111111111:assumed-role/AWSReservedSSO_FullOrgAdmin_x/req@example.com",
     )
-    with patch.object(main_module.sso, "has_account_assignment", return_value=False):
-        result = main_module.handle_cli_access_request(event)
-    assert result == main_module.cli_auth.GENERIC_REJECTION
-
-
-def test_handle_cli_access_request_calls_has_account_assignment_with_the_resolved_account_and_permission_set_arn(main_module):
-    """Regression test: has_account_assignment moved from
-    list_account_assignments_for_principal (documented by AWS as callable
-    only from the IAM Identity Center *management* account -- unusable in
-    this module's own recommended delegated-admin deployment) to
-    list_account_assignments (per account + permission set, no such
-    restriction) -- which needs the real permission_set_arn, not just the
-    name, so this pins that has_account_assignment is actually called with
-    the account/permission-set pair the request resolved to, not called
-    before that resolution happens."""
-    event = _cli_request_event(
-        body={"account": "111111111111", "permission_set": "FullOrgAdmin", "reason": "x", "duration": "1"},
-        user_arn="arn:aws:sts::111111111111:assumed-role/AWSReservedSSO_Foo/req@example.com",
-    )
-    with patch.object(main_module.sso, "has_account_assignment", return_value=True) as mock_check:
-        result = main_module.handle_cli_access_request(event)
-    mock_check.assert_called_once_with(
-        main_module.sso_client,
-        main_module.cfg.sso_instance_arn,
-        "u-req",
-        "111111111111",
-        "arn:aws:sso:::permissionSet/ssoins-1/ps-fullorgadmin",
-    )
-    assert result != main_module.cli_auth.GENERIC_REJECTION
-
-
-def test_handle_cli_access_request_returns_503_on_transient_account_assignment_error(main_module):
-    """A throttled/unavailable list_account_assignments says nothing about
-    whether the assignment exists -- it must not be reported as
-    GENERIC_REJECTION's "your credentials are invalid" (403), nor page the
-    approvals channel as an unexpected error (500). A distinguishable 503
-    lets the CLI tell "retry this" apart from both of those."""
-    event = _cli_request_event(
-        body={"account": "111111111111", "permission_set": "Foo", "reason": "x", "duration": "1"},
-        user_arn="arn:aws:sts::111111111111:assumed-role/AWSReservedSSO_Foo/req@example.com",
-    )
+    fake_requester = MagicMock(id="U_REQ", email="req@example.com")
+    fake_decision = SimpleNamespace(reason=main_module.access_control.DecisionReason.RequiresApproval)
     with (
-        patch.object(main_module.sso, "has_account_assignment", side_effect=main_module.sso.TransientSSOError),
-        patch.object(main_module.app.client, "chat_postMessage") as mock_post_message,
+        patch.object(main_module.slack_helpers, "get_user_by_email", return_value=fake_requester),
+        patch.object(main_module, "process_access_request", return_value=(fake_decision, True)) as mock_process,
     ):
         result = main_module.handle_cli_access_request(event)
-    assert result["statusCode"] == 503
-    mock_post_message.assert_not_called()
+
+    mock_process.assert_called_once()
+    assert result != main_module.cli_auth.GENERIC_REJECTION
+    assert result["statusCode"] == 200
+    assert json.loads(result["body"])["ok"] is True
 
 
 def test_handle_cli_access_request_returns_503_on_transient_account_catalog_error(main_module):
     """Regression test: get_accounts_from_config_with_cache and
     get_permission_sets_from_config_with_cache are cache-backed, but that
     only shields a *warm* cache -- with caching disabled or a cold cache, a
-    throttle propagates the raw botocore error. Like the has_account_assignment
-    transient case above, this must come back as a retryable 503, not the
-    blanket handler's 500 plus a Slack post."""
+    throttle propagates the raw botocore error. This must come back as a
+    retryable 503, not the blanket handler's 500 plus a Slack post."""
     event = _cli_request_event(
         body={"account": "111111111111", "permission_set": "Foo", "reason": "x", "duration": "1"},
         user_arn="arn:aws:sts::111111111111:assumed-role/AWSReservedSSO_Foo/req@example.com",


### PR DESCRIPTION
Fixes #193.

## Root cause

`has_account_assignment` (added in the round-3 remediation, a defense-in-depth check) required a CLI caller to already hold the exact account/permission-set assignment they were requesting before letting the request through. That's backwards for an elevation tool -- the entire point is granting access the caller doesn't currently have. Every genuine first-time elevation request was rejected with `403 GENERIC_REJECTION`; the only thing that ever passed was a redundant re-request of a still-live grant SSO Elevator had itself just issued.

## Verification

Reproduced live against a real 4.4.0 deployment before writing the fix -- not just inferred from the report -- using a genuine SigV4-signed request against an account with zero existing assignment. Confirmed the same 403 Andrey saw, at the exact point in the flow `has_account_assignment` runs.

## Why removed, not rescoped

A correct principal-wide "does this person have any real assignment anywhere" check needs `sso-admin:ListAccountAssignmentsForPrincipal`, which round 3 already established doesn't work from this module's own recommended delegated-admin deployment topology. Any per-account variant has the same "rejects legitimate first-time access" problem. The identity is still verified by SigV4 + `AWS_IAM`, `iam:GetRole`'s reserved-path check (AWS itself blocks non-Identity-Center role creation there), the session name resolving to a real Identity Store user, and the email round-trip cross-check -- this check was the redundant, and actively broken, extra layer on top.

## What's in this PR

- Removes `has_account_assignment` and the now-dead `TransientSSOError` type from `src/sso.py`.
- Removes the call site and its `try/except` in `src/main.py`, with a comment explaining why the check was removed rather than fixed.
- Removes the `sso:ListAccountAssignments` IAM grant that only existed for this check.
- Removes the three tests that had locked in the buggy call shape, adds one proving a request with no prior assignment now succeeds.

## Test plan

- [x] `uv run pytest` -- full suite passes
- [x] `ruff check` / `ruff format --check` -- clean
- [x] `terraform fmt -check -recursive` / `terraform validate` -- clean
- [x] Reproduced the bug live against a real deployment before the fix, will re-verify live against this fix before the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
