### PR TITLE
Fix #193's remaining items + #194 Category A (Slack-path regressions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@ resolve the underlying domain mismatch to minimize security exposure.
 
 SSO Elevator will update request message in channel with Warning, if fallback domains are in use.
 
+**Upgrade note (4.4.0+):** if two or more Identity Store users share the same email case-insensitively, every request from any of them now fails outright with a clear "email collision" error, instead of silently resolving to whichever of them happened to come first in Identity Store's own listing order. If your directory has such a collision, requests from the affected users will start failing on upgrade until it's resolved on the Identity Store side.
+
 Notes:
 - SSO Elevator always prioritizes the primary domain from Slack (the Slack user's email) when searching for a user in AWS SSO.
 - SSO Elevator adds a large warning message in Slack if it uses a secondary fallback domain to find a user in AWS SSO.

--- a/cmd/elevator/README.md
+++ b/cmd/elevator/README.md
@@ -34,10 +34,12 @@ Downloads the right binary for your OS/arch from GitHub Releases, verifies its c
 ```bash
 git clone https://github.com/fivexl/terraform-aws-sso-elevator.git
 cd terraform-aws-sso-elevator/cmd/elevator
-go build -o elevator .
+go build -ldflags "-X main.version=dev -X main.buildCommit=$(git rev-parse --short HEAD) -X main.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o elevator .
 ```
 
 This is a separate, nested Go module (`cmd/elevator/go.mod`) — the rest of this repo is Python/Terraform, so building the CLI doesn't touch or require anything else in the repo.
+
+A plain `go build -o elevator .` (no `-ldflags`) still works, but leaves `main.version`/`main.buildCommit`/`main.buildDate` at their zero values, so `elevator version` reports `elevator dev (commit none, built unknown)` regardless of what was actually built — the `-ldflags` above are what `.goreleaser.yaml` sets for every published release, so a binary built this way reports something meaningful instead.
 
 ### Verifying a release
 

--- a/src/cache.py
+++ b/src/cache.py
@@ -52,6 +52,36 @@ class CacheKey:
 
     ACCOUNTS = "accounts.json"
     PERMISSION_SETS_PREFIX = "permission_sets/"
+    USERS_PREFIX = "users/"
+
+
+# IAM Identity Store IDs are documented as "d-" followed by 10 lowercase
+# hex characters, but that's not a versioned public contract -- matched
+# loosely (a bounded alphanumeric/hyphen string) rather than pinned to
+# that exact shape, the same way _validate_arn exists to reject garbage
+# input before it becomes an S3 key, not to enforce AWS's own format.
+IDENTITY_STORE_ID_PATTERN = re.compile(r"^[\w-]{1,64}$")
+
+
+def _validate_identity_store_id(identity_store_id: str) -> str:
+    """Validate and sanitize an Identity Store ID used as part of a cache key.
+
+    Args:
+        identity_store_id: Identity Store ID to validate
+
+    Returns:
+        Validated identity_store_id string
+
+    Raises:
+        ValueError: If the identity_store_id format is invalid
+    """
+    if not isinstance(identity_store_id, str):
+        raise ValueError(f"identity_store_id must be a string, got {type(identity_store_id)}")
+
+    if not IDENTITY_STORE_ID_PATTERN.match(identity_store_id):
+        raise ValueError(f"Invalid identity_store_id format: {identity_store_id}")
+
+    return identity_store_id
 
 
 def _validate_arn(arn: str) -> str:
@@ -290,6 +320,92 @@ def set_cached_permission_sets(
         logger.warning(f"Validation failed when caching permission sets: {e}", extra={"error": str(e)})
     except Exception as e:
         logger.warning(f"Failed to cache permission sets: {e}", extra={"error": str(e)})
+
+
+def get_cached_users(
+    s3_client: S3Client,
+    cache_config: CacheConfig,
+    identity_store_id: str,
+) -> Optional[list[dict[str, Any]]]:
+    """Get cached Identity Store users (raw dicts, the same shape sso.list_users
+    returns under its "Users" key) from S3.
+
+    Args:
+        s3_client: S3 client
+        cache_config: Cache configuration
+        identity_store_id: Identity Store ID (used as part of cache key)
+
+    Returns:
+        List of cached user dicts or None if cache miss
+    """
+    if not cache_config.enabled:
+        logger.debug("Cache is disabled, skipping cache lookup")
+        return None
+
+    try:
+        validated_bucket_name = _validate_bucket_name(cache_config.bucket_name)
+        validated_identity_store_id = _validate_identity_store_id(identity_store_id)
+
+        key = f"{CacheKey.USERS_PREFIX}{validated_identity_store_id}.json"
+
+        response = s3_client.get_object(
+            Bucket=validated_bucket_name,
+            Key=key,
+        )
+
+        users = json.loads(response["Body"].read().decode("utf-8"))
+
+        logger.info(f"Retrieved {len(users)} users from cache")
+        return users
+
+    except s3_client.exceptions.NoSuchKey:
+        logger.info("Cache miss for users - no cached data found")
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to get cached users: {e}", extra={"error": str(e)})
+        return None
+
+
+def set_cached_users(
+    s3_client: S3Client,
+    cache_config: CacheConfig,
+    identity_store_id: str,
+    users: list[dict[str, Any]],
+) -> None:
+    """Store Identity Store users (raw dicts) in S3 cache.
+
+    Args:
+        s3_client: S3 client
+        cache_config: Cache configuration
+        identity_store_id: Identity Store ID (used as part of cache key)
+        users: List of user dicts to cache
+    """
+    if not cache_config.enabled:
+        logger.debug("Cache is disabled, skipping cache write")
+        return
+
+    try:
+        validated_bucket_name = _validate_bucket_name(cache_config.bucket_name)
+        validated_identity_store_id = _validate_identity_store_id(identity_store_id)
+
+        sanitized_data = _sanitize_json_data(users)
+
+        key = f"{CacheKey.USERS_PREFIX}{validated_identity_store_id}.json"
+
+        s3_client.put_object(
+            Bucket=validated_bucket_name,
+            Key=key,
+            Body=sanitized_data.encode("utf-8"),
+            ContentType="application/json",
+            ServerSideEncryption="AES256",
+        )
+
+        logger.info(f"Cached {len(users)} users")
+
+    except ValueError as e:
+        logger.warning(f"Validation failed when caching users: {e}", extra={"error": str(e)})
+    except Exception as e:
+        logger.warning(f"Failed to cache users: {e}", extra={"error": str(e)})
 
 
 def _compute_data_hash(data: T) -> str:

--- a/src/cli_auth.py
+++ b/src/cli_auth.py
@@ -47,6 +47,7 @@ import sso
 
 if TYPE_CHECKING:
     from mypy_boto3_identitystore import IdentityStoreClient
+    from mypy_boto3_s3 import S3Client
 
 # Matches all three real AWS partitions (aws, aws-cn, aws-us-gov) -- a
 # hardcoded "aws" would reject 100% of requests in GovCloud/China with the
@@ -128,7 +129,9 @@ GENERIC_REJECTION = {
 }
 
 
-def extract_identity(user_arn: str, identity_store_client: "IdentityStoreClient", identity_store_id: str) -> tuple[str, str, dict] | None:
+def extract_identity(
+    user_arn: str, identity_store_client: "IdentityStoreClient", identity_store_id: str, s3_client: "S3Client"
+) -> tuple[str, str, dict] | None:
     """Return the requester's real, registered (email, UserId, the full
     list_users() snapshot they were matched against), but only if user_arn is
     an assumed-role session in the expected account, under a role that's
@@ -171,17 +174,26 @@ def extract_identity(user_arn: str, identity_store_client: "IdentityStoreClient"
     # all) work here the same way it already does on the Slack path.
     #
     # This is a full paginated Identity Store scan -- the call on this path
-    # most likely to throttle -- so it gets the same transient-vs-real
-    # distinction _is_sso_provisioned_role's iam:GetRole call already makes:
-    # a throttle/5xx/connectivity failure says nothing about whether the
-    # caller's identity is valid, so it's surfaced as TransientIAMError
-    # (a 503 the CLI can retry) rather than falling through to the generic
-    # exception handler as a 500 plus a Slack post. A non-transient
-    # ClientError (e.g. this Lambda's own IAM policy unexpectedly missing
-    # identitystore:ListUsers) is a real misconfiguration, not something to
-    # silently swallow -- that's left to propagate and page the channel.
+    # most likely to throttle -- so it goes through list_users_with_cache
+    # (#193 item 2), not the raw, uncached list_users: every account/
+    # permission-set catalog lookup on this same path already gets S3-backed
+    # cache resilience, but this call, arguably the most throttle-prone one
+    # here, previously had none at all -- every single CLI request paid for
+    # a fresh scan with no fallback. The remaining try/except below still
+    # matters for a *cold* cache (or caching disabled): list_users_with_cache
+    # only absorbs a throttle/5xx silently when it has cached data to fall
+    # back to, and re-raises the raw error otherwise -- the same
+    # transient-vs-real distinction _is_sso_provisioned_role's iam:GetRole
+    # call already makes: a throttle/5xx/connectivity failure says nothing
+    # about whether the caller's identity is valid, so it's surfaced as
+    # TransientIAMError (a 503 the CLI can retry) rather than falling
+    # through to the generic exception handler as a 500 plus a Slack post.
+    # A non-transient ClientError (e.g. this Lambda's own IAM policy
+    # unexpectedly missing identitystore:ListUsers) is a real
+    # misconfiguration, not something to silently swallow -- that's left to
+    # propagate and page the channel.
     try:
-        list_of_users = sso.list_users(identity_store_client, identity_store_id)
+        list_of_users = sso.list_users_with_cache(identity_store_client, identity_store_id, s3_client, cfg)
     except botocore.exceptions.ClientError as e:
         if _is_transient(e):
             raise TransientIAMError from e

--- a/src/group.py
+++ b/src/group.py
@@ -154,56 +154,91 @@ def handle_request_for_group_access_submittion(
 
     is_user_in_channel = slack_helpers.check_if_user_is_in_channel(client, cfg.slack_channel_id, requester.id)
 
-    logger.info(f"Sending message to the channel {cfg.slack_channel_id}, message: {text}")
-    client.chat_postMessage(text=text, thread_ts=slack_response["ts"], channel=cfg.slack_channel_id)
-    if cfg.send_dm_if_user_not_in_channel and not is_user_in_channel:
-        logger.info(f"User {requester.id} is not in the channel. Sending DM with message: {dm_text}")
-        client.chat_postMessage(
-            channel=requester.id,
-            text=f"""
-            {dm_text} You are receiving this message in a DM because you are not a member of the channel <#{cfg.slack_channel_id}>.
-            """,
+    # execute_decision_on_group_request runs before every notification below
+    # (#194 A3, mirroring main.py's process_access_request) -- not after,
+    # with the message already recolored to reflect an auto-grant decision.
+    # For ApprovalNotRequired/SelfApproval, text/color_coding_emoji above are
+    # already the "will be approved automatically" / good_result_emoji
+    # wording purely from the *decision*, before the grant has actually been
+    # attempted. Posting any notification before running the real AWS calls
+    # here means a failure (a stale group id, IAM Identity Center throttling,
+    # anything) left every message permanently reading "will be approved
+    # automatically" with no correction. For RequiresApproval, decision.grant
+    # is still False here, so execute_decision_on_group_request's own
+    # `if not decision.grant: return False` makes this a no-op -- this only
+    # changes behavior for the two auto-grant reasons.
+    grant_error: Exception | None = None
+    try:
+        access_control.execute_decision_on_group_request(
+            group=group,
+            permission_duration=request.permission_duration,
+            approver=requester,
+            requester=requester,
+            reason=request.reason,
+            decision=decision,
+            identity_store_id=identity_store_id,
         )
-
-    blocks = slack_helpers.HeaderSectionBlock.set_color_coding(
-        blocks=slack_response["message"]["blocks"],
-        color_coding_emoji=color_coding_emoji,
-    )
-    client.chat_update(
-        channel=cfg.slack_channel_id,
-        ts=slack_response["ts"],
-        blocks=blocks,
-        text=text,
-    )
-
-    access_control.execute_decision_on_group_request(
-        group=group,
-        permission_duration=request.permission_duration,
-        approver=requester,
-        requester=requester,
-        reason=request.reason,
-        decision=decision,
-        identity_store_id=identity_store_id,
-    )
-
-    if decision.grant:
-        client.chat_postMessage(
-            channel=cfg.slack_channel_id,
-            text=f"Permissions granted to <@{requester.id}>",
-            thread_ts=slack_response["ts"],
+    except Exception as e:  # noqa: BLE001
+        grant_error = e
+        logger.exception(
+            "execute_decision_on_group_request failed -- overriding the message to reflect the actual outcome",
+            extra={"decision": decision.dict()},
         )
-        if not is_user_in_channel and cfg.send_dm_if_user_not_in_channel:
+        color_coding_emoji = cfg.bad_result_emoji
+        text = f"An error occurred while granting access: {e}"
+        dm_text = text
+
+    # Everything below is best-effort, not re-raised: once the grant has
+    # either succeeded (access is live) or definitively failed (captured as
+    # grant_error above), a Slack API hiccup while posting/updating these
+    # notifications must never be reported as "this failed" on top of a
+    # grant that actually succeeded.
+    try:
+        logger.info(f"Sending message to the channel {cfg.slack_channel_id}, message: {text}")
+        client.chat_postMessage(text=text, thread_ts=slack_response["ts"], channel=cfg.slack_channel_id)
+        if cfg.send_dm_if_user_not_in_channel and not is_user_in_channel:
+            logger.info(f"User {requester.id} is not in the channel. Sending DM with message: {dm_text}")
             client.chat_postMessage(
                 channel=requester.id,
-                text="Your request was processed, permissions granted.",
+                text=f"""
+                {dm_text} You are receiving this message in a DM because you are not a member of the channel <#{cfg.slack_channel_id}>.
+                """,
             )
+
+        blocks = slack_helpers.HeaderSectionBlock.set_color_coding(
+            blocks=slack_response["message"]["blocks"],
+            color_coding_emoji=color_coding_emoji,
+        )
+        client.chat_update(
+            channel=cfg.slack_channel_id,
+            ts=slack_response["ts"],
+            blocks=blocks,
+            text=text,
+        )
+
+        if decision.grant and grant_error is None:
+            client.chat_postMessage(
+                channel=cfg.slack_channel_id,
+                text=f"Permissions granted to <@{requester.id}>",
+                thread_ts=slack_response["ts"],
+            )
+            if not is_user_in_channel and cfg.send_dm_if_user_not_in_channel:
+                client.chat_postMessage(
+                    channel=requester.id,
+                    text="Your request was processed, permissions granted.",
+                )
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to fully post/update notifications about this request's outcome (best-effort, not re-raised)")
+
+    if grant_error is not None:
+        raise grant_error
 
 
 cache_for_dublicate_requests = {}
 
 
 @handle_errors
-def handle_group_button_click(body: dict, client: WebClient, context: BoltContext) -> SlackResponse:  # type: ignore # noqa: PGH003 ARG001
+def handle_group_button_click(body: dict, client: WebClient, context: BoltContext) -> SlackResponse | None:  # type: ignore # noqa: PGH003 ARG001 PLR0915
     logger.info("Handling button click")
     payload = slack_helpers.ButtonGroupClickedPayload.model_validate(body)
     logger.info("Button click payload", extra={"payload": payload})
@@ -273,35 +308,89 @@ def handle_group_button_click(body: dict, client: WebClient, context: BoltContex
 
     text = f"Permissions granted to <@{requester.id}> by <@{approver.id}>."
     dm_text = f"Your request was approved by <@{approver.id}>. Permissions granted."
+
+    # Buttons stripped *before* execute_decision_on_group_request runs, not
+    # only afterward together with the rest of the outcome (#194 A2/A3):
+    # cache_for_dublicate_requests is per-container in-memory state, so it
+    # can't close this window by itself -- a second approver clicking
+    # Approve while the grant is still in progress can land in a different,
+    # fresh Lambda container that sees an empty cache and this message's
+    # still-live buttons. Best-effort: a Slack hiccup here narrows the
+    # closed window rather than eliminating it, but must not stop the
+    # actual grant from being attempted.
+    try:
+        client.chat_update(
+            channel=payload.channel_id,
+            ts=payload.thread_ts,
+            blocks=slack_helpers.remove_blocks(payload.message["blocks"], block_ids=["buttons"]),
+            text=f"<@{approver.id}> is processing this request...",
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to strip buttons before granting (best-effort, not re-raised)")
+
+    # execute_decision_on_group_request runs before the chat_update/
+    # notifications below, not after: the old order recolored the message
+    # green and said "Permissions granted" before the grant had actually
+    # been attempted, so a failure here left that message incorrect with no
+    # visible correction. Same shape as main.py's handle_button_click.
+    grant_error: Exception | None = None
+    try:
+        access_control.execute_decision_on_group_request(
+            decision=decision,
+            group=sso.describe_group(identity_store_id, payload.request.group_id, identity_store_client),
+            permission_duration=payload.request.permission_duration,
+            approver=approver,
+            requester=requester,
+            reason=payload.request.reason,
+            identity_store_id=identity_store_id,
+        )
+    except Exception as e:  # noqa: BLE001
+        grant_error = e
+        logger.exception(
+            "execute_decision_on_group_request failed -- overriding the message to reflect the actual outcome",
+            extra={"decision": decision.dict()},
+        )
+        text = f"An error occurred while granting access: {e}"
+        dm_text = text
+
+    # The dedup cache is cleared once the outcome is decided (success or a
+    # caught failure), not only on the success path -- otherwise a failed
+    # execute_decision_on_group_request left this exact request permanently
+    # stuck reporting "already in progress" to any retry.
+    cache_for_dublicate_requests.clear()
+
     blocks = slack_helpers.HeaderSectionBlock.set_color_coding(
         blocks=payload.message["blocks"],
-        color_coding_emoji=cfg.good_result_emoji,
+        color_coding_emoji=cfg.bad_result_emoji if grant_error is not None else cfg.good_result_emoji,
     )
-
     blocks = slack_helpers.remove_blocks(blocks, block_ids=["buttons"])
     blocks.append(slack_helpers.button_click_info_block(payload.action, approver.id).to_dict())
-    client.chat_update(
-        channel=payload.channel_id,
-        ts=payload.thread_ts,
-        blocks=blocks,
-        text=text,
-    )
 
-    access_control.execute_decision_on_group_request(
-        decision=decision,
-        group=sso.describe_group(identity_store_id, payload.request.group_id, identity_store_client),
-        permission_duration=payload.request.permission_duration,
-        approver=approver,
-        requester=requester,
-        reason=payload.request.reason,
-        identity_store_id=identity_store_id,
-    )
-    cache_for_dublicate_requests.clear()
-    if cfg.send_dm_if_user_not_in_channel and not is_user_in_channel:
-        logger.info(f"User {requester.id} is not in the channel. Sending DM with message: {dm_text}")
-        client.chat_postMessage(channel=requester.id, text=dm_text)
-    return client.chat_postMessage(
-        channel=payload.channel_id,
-        text=text,
-        thread_ts=payload.thread_ts,
-    )
+    # Best-effort from here, not re-raised: once execute_decision_on_group_request
+    # has either succeeded (access is live) or definitively failed (captured
+    # as grant_error above), a Slack API hiccup while posting/updating these
+    # notifications must never be reported as "this failed" on top of a
+    # grant that actually succeeded.
+    result: SlackResponse | None = None
+    try:
+        client.chat_update(
+            channel=payload.channel_id,
+            ts=payload.thread_ts,
+            blocks=blocks,
+            text=text,
+        )
+        if cfg.send_dm_if_user_not_in_channel and not is_user_in_channel:
+            logger.info(f"User {requester.id} is not in the channel. Sending DM with message: {dm_text}")
+            client.chat_postMessage(channel=requester.id, text=dm_text)
+        result = client.chat_postMessage(
+            channel=payload.channel_id,
+            text=text,
+            thread_ts=payload.thread_ts,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to fully post/update notifications about this approval's outcome (best-effort, not re-raised)")
+
+    if grant_error is not None:
+        raise grant_error
+
+    return result

--- a/src/main.py
+++ b/src/main.py
@@ -106,22 +106,20 @@ def handle_cli_access_request(event: dict) -> dict:  # noqa: PLR0911, PLR0912, P
         user_arn = iam_context.get("userArn", "")
         logger.debug("Authorizer IAM userArn", extra={"user_arn": user_arn})
 
-        try:
-            identity = cli_auth.extract_identity(user_arn, identity_store_client, group.identity_store_id) if user_arn else None
-        except cli_auth.TransientIAMError:
-            # IAM couldn't answer iam:GetRole right now (throttled, a 5xx,
-            # briefly unavailable) -- this says nothing about whether the
-            # caller's identity is valid, so it shouldn't be reported as
-            # GENERIC_REJECTION's "your credentials are invalid", nor paged
-            # to the approvals channel as an unexpected error. A 503 tells
-            # the caller this is worth retrying.
-            logger.warning("Transient IAM error while verifying CLI identity; asking the caller to retry")
-            return _transient_aws_error_response()
-        if not identity:
-            logger.info("Rejected CLI request: could not verify a signed identity with an email")
-            return cli_auth.GENERIC_REJECTION
-        identity_email, identity_user_id, list_of_users = identity
-
+        # Cheap request-body validation (JSON syntax, field presence, reason
+        # length, duration format -- all local, no AWS calls) happens before
+        # cli_auth.extract_identity below, not after (#193 item 1): that
+        # call does an iam:GetRole plus a full paginated
+        # identitystore:ListUsers scan, the single most expensive thing on
+        # this path. A caller sending malformed JSON, a non-object body,
+        # missing fields, or an over-length reason used to still pay for
+        # both AWS calls before getting its 400 -- and since this route's
+        # AWS_IAM authorizer only proves the caller can *sign* a request,
+        # not that they're a legitimate SSO principal, this meant anyone
+        # able to sign a request (not just genuine SSO users) could drive
+        # full Identity Store scans with garbage payloads at the route's
+        # throttle. Validating the body first rejects that for free, before
+        # any AWS call runs at all.
         try:
             body = json.loads(event.get("body") or "{}")
         except json.JSONDecodeError:
@@ -168,13 +166,20 @@ def handle_cli_access_request(event: dict) -> dict:  # noqa: PLR0911, PLR0912, P
         # in for that field, not just Slack's own 2000: a reason of, say,
         # 1996 characters passed a plain 2000 check but produced a
         # 2004-character field once wrapped, still overflowing.
+        #
+        # Checked against the *escaped* length, not len(reason): escape_mrkdwn
+        # expands "&" to "&amp;" (5x) and "<"/">" to "&lt;"/"&gt;" (4x), and
+        # that's what actually lands in the field -- 399 "&" characters alone
+        # is enough to blow past Slack's 2000-char limit even though the raw
+        # string is nowhere near it, which is exactly what this cap exists to
+        # prevent.
         reason_prefix = "Reason: "
         max_reason_length = 2000 - len(reason_prefix)
-        if len(reason) > max_reason_length:
+        if len(slack_helpers.escape_mrkdwn(reason)) > max_reason_length:
             return {
                 "statusCode": 400,
                 "headers": {"content-type": "application/json"},
-                "body": json.dumps({"message": f"reason must be at most {max_reason_length} characters."}),
+                "body": json.dumps({"message": f"reason must be at most {max_reason_length} characters (after escaping any of & < >)."}),
             }
 
         # A strict, length-bounded digit-string match rather than a bare
@@ -221,6 +226,26 @@ def handle_cli_access_request(event: dict) -> dict:  # noqa: PLR0911, PLR0912, P
                     }
                 ),
             }
+
+        # Identity verification (iam:GetRole plus a full paginated
+        # identitystore:ListUsers scan) runs only now, after every cheap,
+        # local check on the body above has already passed -- see the
+        # comment where user_arn is extracted for why.
+        try:
+            identity = cli_auth.extract_identity(user_arn, identity_store_client, group.identity_store_id, s3_client) if user_arn else None
+        except cli_auth.TransientIAMError:
+            # IAM couldn't answer iam:GetRole right now (throttled, a 5xx,
+            # briefly unavailable) -- this says nothing about whether the
+            # caller's identity is valid, so it shouldn't be reported as
+            # GENERIC_REJECTION's "your credentials are invalid", nor paged
+            # to the approvals channel as an unexpected error. A 503 tells
+            # the caller this is worth retrying.
+            logger.warning("Transient IAM error while verifying CLI identity; asking the caller to retry")
+            return _transient_aws_error_response()
+        if not identity:
+            logger.info("Rejected CLI request: could not verify a signed identity with an email")
+            return cli_auth.GENERIC_REJECTION
+        identity_email, identity_user_id, list_of_users = identity
 
         # The Slack modal can't submit a malformed account or an unlisted
         # permission set at all -- both fields are populated selects built
@@ -698,6 +723,30 @@ def handle_button_click(body: dict, client: WebClient, context: BoltContext) -> 
     dm_text = f"Your request was approved by <@{approver.id}>. Permissions granted."
     color_coding_emoji = cfg.good_result_emoji
 
+    # Buttons stripped *before* execute_decision runs, not only afterward
+    # with the rest of the outcome (#194 A2): cache_for_dublicate_requests
+    # is per-container in-memory state, so it can't close this window by
+    # itself -- a second approver clicking Approve while
+    # create_account_assignment_and_wait_for_result is still polling can
+    # land in a different, fresh Lambda container that sees an empty cache
+    # and this message's still-live buttons, and runs a second
+    # execute_decision -> schedule_revoke_event for the same request. Once
+    # the buttons are gone there's nothing left for a second click to hit,
+    # regardless of which container it would have landed in. Best-effort:
+    # a Slack hiccup here narrows the closed window rather than eliminating
+    # it, but must not stop the actual grant from being attempted -- the
+    # final chat_update after execute_decision still removes the buttons
+    # for good either way.
+    try:
+        client.chat_update(
+            channel=payload.channel_id,
+            ts=payload.thread_ts,
+            blocks=slack_helpers.remove_blocks(payload.message["blocks"], block_ids=["buttons"]),
+            text=f"<@{approver.id}> is processing this request...",
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to strip buttons before granting (best-effort, not re-raised)")
+
     # execute_decision runs before the chat_update/notifications below, not
     # after: the old order recolored the message green and said
     # "Permissions granted" before the grant had actually been attempted,
@@ -950,6 +999,24 @@ def process_access_request(  # noqa: PLR0915, PLR0912
         text = f"An error occurred while granting access: {e}"
         dm_text = text
 
+    # Isolated in its own try, not the first statement inside the shared
+    # best-effort block below (#194 A4): it used to be, so its failure
+    # aborted the thread reply, header chat_update, DM and "granted"
+    # follow-up all at once -- while succeeded (computed from
+    # color_coding_emoji, set above, before any of this) stayed True, so a
+    # CLI caller saw ok:true for a grant nobody was ever actually told
+    # about. Defaults to False (not confirmed in the channel) on failure,
+    # not True: that means the DM-if-not-in-channel fallback below still
+    # fires, so a membership-check hiccup fails toward over-notifying
+    # (an extra DM to someone already in the channel) rather than under-
+    # notifying (skipping the only notification a requester who genuinely
+    # isn't in the channel would see).
+    try:
+        is_user_in_channel = slack_helpers.check_if_user_is_in_channel(client, cfg.slack_channel_id, requester.id)
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to check channel membership; assuming not in channel so the DM fallback still fires")
+        is_user_in_channel = False
+
     # Everything below is notification about an outcome that's already
     # final by this point (execute_decision either succeeded -- access is
     # live -- or failed outright -- nothing was granted, captured as
@@ -962,8 +1029,6 @@ def process_access_request(  # noqa: PLR0915, PLR0912
     # below, after this block, unconditionally) can still make the
     # caller-visible outcome a failure.
     try:
-        is_user_in_channel = slack_helpers.check_if_user_is_in_channel(client, cfg.slack_channel_id, requester.id)
-
         logger.info(f"Sending message to the channel {cfg.slack_channel_id}, message: {text}")
         client.chat_postMessage(text=text, thread_ts=slack_response["ts"], channel=cfg.slack_channel_id)
         if cfg.send_dm_if_user_not_in_channel and not is_user_in_channel:

--- a/src/sso.py
+++ b/src/sso.py
@@ -367,6 +367,45 @@ def list_users(client: IdentityStoreClient, identity_store_id: str) -> dict:
     return r
 
 
+def list_users_with_cache(
+    client: IdentityStoreClient,
+    identity_store_id: str,
+    s3_client: S3Client,
+    cfg: config.Config,
+) -> dict:
+    """List all Identity Store users with cache resilience, same shape and
+    resilience contract as list_permission_sets_with_cache above (#193 item
+    2): list_users is a full paginated scan, documented elsewhere
+    in this module as the call on the CLI path most likely to throttle, and
+    unlike the account and permission-set catalogs it used to have no
+    caching at all -- every single CLI request paid for a fresh scan, with
+    no fallback if that scan happened to throttle.
+
+    This function calls both the Identity Store API and S3 cache in parallel.
+    If the API call succeeds, it compares with cached data and updates if different.
+    If the API call fails, it falls back to cached data.
+
+    Args:
+        client: Identity Store client
+        identity_store_id: Identity Store ID
+        s3_client: S3 client for cache
+        cfg: Application configuration
+
+    Returns:
+        dict shaped like list_users' own return value (a "Users" key holding
+        the full list), not the raw cached list directly.
+    """
+    cache_config = cache_module.CacheConfig.from_config(cfg)
+
+    users = cache_module.with_cache_resilience(
+        cache_getter=lambda: cache_module.get_cached_users(s3_client, cache_config, identity_store_id),
+        api_getter=lambda: list_users(client, identity_store_id)["Users"],
+        cache_setter=lambda users: cache_module.set_cached_users(s3_client, cache_config, identity_store_id, users),
+        resource_name="users",
+    )
+    return {"Users": users}
+
+
 def find_email_by_username(list_of_users: dict, username: str) -> tuple[str, str] | None:
     """Look up a user's real, registered email (and their UserId) by their exact
     IAM Identity Center username (the UserName attribute — what IAM Identity

--- a/src/tests/test_cache.py
+++ b/src/tests/test_cache.py
@@ -294,6 +294,91 @@ class TestSetCachedPermissionSets:
         assert "permission_sets/" in call_args[1]["Key"]
 
 
+@pytest.fixture
+def sample_users():
+    """Sample Identity Store user dicts, the same raw shape sso.list_users
+    returns under its "Users" key -- unlike accounts/permission sets, users
+    aren't cached through a pydantic model."""
+    return [
+        {"UserId": "u-1", "UserName": "alice@example.com", "Emails": [{"Value": "alice@example.com", "Primary": True}]},
+        {"UserId": "u-2", "UserName": "bob@example.com", "Emails": [{"Value": "bob@example.com", "Primary": True}]},
+    ]
+
+
+class TestGetCachedUsers:
+    """Tests for get_cached_users function (#193 item 2)."""
+
+    def test_cache_disabled_returns_none(self, mock_s3_client, cache_config_disabled):
+        """When cache is disabled, should return None without calling S3."""
+        result = cache_module.get_cached_users(mock_s3_client, cache_config_disabled, "d-1234567890")
+
+        assert result is None
+        mock_s3_client.get_object.assert_not_called()
+
+    def test_cache_miss_no_object(self, mock_s3_client, cache_config_enabled):
+        """When object not found in cache, should return None."""
+        mock_s3_client.get_object.side_effect = mock_s3_client.exceptions.NoSuchKey()
+
+        result = cache_module.get_cached_users(mock_s3_client, cache_config_enabled, "d-1234567890")
+
+        assert result is None
+        mock_s3_client.get_object.assert_called_once()
+
+    def test_cache_hit_valid_data(self, mock_s3_client, cache_config_enabled, sample_users):
+        """When cache has valid data, should return the raw user dicts."""
+        body_mock = Mock()
+        body_mock.read.return_value = json.dumps(sample_users).encode("utf-8")
+        mock_s3_client.get_object.return_value = {"Body": body_mock}
+
+        result = cache_module.get_cached_users(mock_s3_client, cache_config_enabled, "d-1234567890")
+
+        assert result == sample_users
+
+    def test_invalid_identity_store_id_returns_none(self, mock_s3_client, cache_config_enabled):
+        """An identity_store_id that fails validation must degrade to a
+        cache miss, the same as any other lookup failure -- not raise and
+        take the whole request down."""
+        result = cache_module.get_cached_users(mock_s3_client, cache_config_enabled, "not valid! id")
+
+        assert result is None
+        mock_s3_client.get_object.assert_not_called()
+
+    def test_generic_exception(self, mock_s3_client, cache_config_enabled):
+        """When generic exception occurs, should return None gracefully."""
+        mock_s3_client.get_object.side_effect = Exception("Something went wrong")
+
+        result = cache_module.get_cached_users(mock_s3_client, cache_config_enabled, "d-1234567890")
+
+        assert result is None
+
+
+class TestSetCachedUsers:
+    """Tests for set_cached_users function (#193 item 2)."""
+
+    def test_cache_disabled_no_write(self, mock_s3_client, cache_config_disabled, sample_users):
+        """When cache is disabled, should not write to S3."""
+        cache_module.set_cached_users(mock_s3_client, cache_config_disabled, "d-1234567890", sample_users)
+
+        mock_s3_client.put_object.assert_not_called()
+
+    def test_successful_write(self, mock_s3_client, cache_config_enabled, sample_users):
+        """When cache is enabled, should write to S3, keyed by identity_store_id."""
+        cache_module.set_cached_users(mock_s3_client, cache_config_enabled, "d-1234567890", sample_users)
+
+        mock_s3_client.put_object.assert_called_once()
+        call_args = mock_s3_client.put_object.call_args
+        assert call_args[1]["Bucket"] == "test-config-bucket"
+        assert call_args[1]["Key"] == "users/d-1234567890.json"
+        assert call_args[1]["ContentType"] == "application/json"
+
+    def test_generic_exception_during_write(self, mock_s3_client, cache_config_enabled, sample_users):
+        """When generic exception occurs during write, should fail gracefully."""
+        mock_s3_client.put_object.side_effect = Exception("Something went wrong")
+
+        # Should not raise exception
+        cache_module.set_cached_users(mock_s3_client, cache_config_enabled, "d-1234567890", sample_users)
+
+
 class TestCacheResilience:
     """Tests for with_cache_resilience function."""
 

--- a/src/tests/test_cli_auth.py
+++ b/src/tests/test_cli_auth.py
@@ -84,10 +84,13 @@ def _unrecognized_5xx() -> botocore.exceptions.ClientError:
     )
 
 
-def extract_identity(user_arn: str, identity_store_client=None):
-    """extract_identity always takes an identity store client + id now --
-    this wrapper lets most call sites in this file omit the boilerplate."""
-    return cli_auth.extract_identity(user_arn, identity_store_client, IDENTITY_STORE_ID)
+def extract_identity(user_arn: str, identity_store_client=None, s3_client=None):
+    """extract_identity always takes an identity store client + id + s3
+    client now -- this wrapper lets most call sites in this file omit the
+    boilerplate. s3_client is unused by any test here directly since
+    mock_list_users below patches list_users_with_cache as a whole, but the
+    real signature still needs a value in its place."""
+    return cli_auth.extract_identity(user_arn, identity_store_client, IDENTITY_STORE_ID, s3_client)
 
 
 @pytest.fixture(autouse=True)
@@ -102,12 +105,16 @@ def mock_iam_client():
 
 @pytest.fixture(autouse=True)
 def mock_list_users():
-    """Stubs the Identity Store list_users call extract_identity makes before
-    find_email_by_username -- the returned content doesn't matter here since
-    find_email_by_username itself is separately mocked below, this just
-    stands in for the identity_store_client=None passed by the extract_identity
-    wrapper above."""
-    with patch.object(cli_auth.sso, "list_users", return_value={"Users": []}) as mock_list:
+    """Stubs the cached Identity Store list_users call extract_identity makes
+    before find_email_by_username -- the returned content doesn't matter
+    here since find_email_by_username itself is separately mocked below,
+    this just stands in for the identity_store_client=None/s3_client=None
+    passed by the extract_identity wrapper above. Patches
+    list_users_with_cache as a whole (#193 item 2 added caching), not the
+    raw list_users it wraps -- exercising the real cache-resilience
+    machinery here would mean mocking S3 and threading for no test value,
+    since that machinery is covered on its own in test_cache.py/test_sso.py."""
+    with patch.object(cli_auth.sso, "list_users_with_cache", return_value={"Users": []}) as mock_list:
         yield mock_list
 
 

--- a/src/tests/test_group.py
+++ b/src/tests/test_group.py
@@ -309,3 +309,58 @@ def test_group_approval_lookup_error_is_retryable(group_module, slack_client):
         assert group_module.cache_for_dublicate_requests == {}
         assert slack_client.chat_postMessage.call_count == 2
         assert all("unexpected error" in call.kwargs["text"] for call in slack_client.chat_postMessage.call_args_list)
+
+
+def test_group_button_click_reflects_a_grant_failure_and_clears_the_dedup_cache(group_module, slack_client):
+    """Regression test (#194 A3): handle_group_button_click had the same
+    "recolor green before the grant is attempted" bug main.py's
+    handle_button_click independently had, since the two don't share this
+    code path -- execute_decision_on_group_request now runs before the
+    final chat_update, so a failure overrides the message instead of
+    leaving it permanently reading "Permissions granted". Also: the dedup
+    cache used to only clear on success, leaving a failed request stuck
+    reporting "already in progress" to every retry."""
+    payload = MagicMock(
+        approver_slack_id=APPROVER_1.id,
+        action=entities.ApproverAction.Approve,
+        channel_id="C_CHAN",
+        thread_ts="1234567890.123456",
+        message={"blocks": list(FAKE_BLOCKS)},
+    )
+    payload.request.requester_slack_id = REQUESTER.id
+    payload.request.group_id = GROUP.id
+
+    fake_decision = access_control.ApproveRequestDecision(grant=True, permit=True, based_on_statements=frozenset())
+
+    with (
+        patch.object(group_module, "slack_helpers") as mock_sh,
+        patch.object(group_module, "access_control") as mock_ac,
+        patch.object(group_module, "sso") as mock_sso,
+    ):
+        mock_sh.ButtonGroupClickedPayload.model_validate.return_value = payload
+        mock_sh.get_user.side_effect = [APPROVER_1, REQUESTER]
+        mock_sh.remove_blocks.side_effect = lambda blocks, block_ids: blocks  # noqa: ARG005
+        mock_sh.check_if_user_is_in_channel.return_value = True
+        mock_ac.get_requester_group_ids_if_needed.return_value = frozenset()
+        mock_ac.make_decision_on_approve_request.return_value = fake_decision
+        mock_ac.execute_decision_on_group_request.side_effect = RuntimeError("boom: group not found")
+        mock_sso.describe_group.return_value = GROUP
+        group_module.cache_for_dublicate_requests.clear()
+
+        group_module.handle_group_button_click(
+            body={},
+            client=slack_client,
+            context={"user_id": APPROVER_1.id},
+        )
+
+    # The dedup cache must not be left stuck on a caught failure.
+    assert group_module.cache_for_dublicate_requests == {}
+    # The final chat_update must reflect the failure, not "Permissions granted".
+    update_calls = slack_client.chat_update.call_args_list
+    assert len(update_calls) >= 2, "expected the early button-strip update plus the final outcome update"
+    final_update_text = update_calls[-1].kwargs["text"]
+    assert "error occurred" in final_update_text.lower()
+    assert "permissions granted" not in final_update_text.lower()
+    # @handle_errors' own generic post is a separate message, not a fix to
+    # the header above -- both must reflect the failure.
+    assert any("unexpected error" in (c.kwargs.get("text") or "").lower() for c in slack_client.chat_postMessage.call_args_list)

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -207,7 +207,11 @@ def test_handle_cli_access_request_rejects_missing_api_id(main_module):
 
 
 def test_handle_cli_access_request_rejects_missing_authorizer_context(main_module):
-    event = _cli_request_event(body={"account": "111111111111"})
+    # A complete, otherwise-valid body -- not just {"account": ...} -- since
+    # body validation now runs before the identity check (#193 item 1); an
+    # incomplete body here would be rejected by that check instead of the
+    # authorizer-missing check this test means to isolate.
+    event = _cli_request_event(body={"account": "111111111111", "permission_set": "Foo", "reason": "x", "duration": "1"})
     result = main_module.handle_cli_access_request(event)
     assert result == main_module.cli_auth.GENERIC_REJECTION
 
@@ -218,7 +222,7 @@ def test_handle_cli_access_request_rejects_explicit_null_authorizer(main_module)
     applies its default when the key is absent, so "authorizer": null
     used to reach .get("iam") on None and raise, turning this into a 500
     with a Slack post instead of the same clean 403 a missing key gets."""
-    event = _cli_request_event(body={"account": "111111111111"})
+    event = _cli_request_event(body={"account": "111111111111", "permission_set": "Foo", "reason": "x", "duration": "1"})
     event["requestContext"]["authorizer"] = None
     result = main_module.handle_cli_access_request(event)
     assert result == main_module.cli_auth.GENERIC_REJECTION
@@ -371,6 +375,22 @@ def test_handle_cli_access_request_rejects_non_object_json_body(main_module):
     assert result["statusCode"] == 400
 
 
+def test_handle_cli_access_request_rejects_malformed_body_without_resolving_identity(main_module):
+    """Regression test (#193 item 1): cheap request-body validation must run
+    before cli_auth.extract_identity, not after -- that call does an
+    iam:GetRole plus a full paginated identitystore:ListUsers scan, and a
+    caller sending a malformed body used to pay for both before getting its
+    400. Verified directly: extract_identity must never even be called for
+    a body this broken, regardless of what a real call to it would have
+    resolved."""
+    event = _cli_request_event(user_arn="arn:aws:sts::111111111111:assumed-role/AWSReservedSSO_Foo/req@example.com")
+    event["body"] = "{not json"
+    with patch.object(main_module.cli_auth, "extract_identity") as mock_extract_identity:
+        result = main_module.handle_cli_access_request(event)
+    mock_extract_identity.assert_not_called()
+    assert result["statusCode"] == 400
+
+
 def test_handle_cli_access_request_rejects_oversized_reason(main_module):
     """Slack's section-block text fields cap at 2000 chars; an oversized
     reason used to reach chat_postMessage unbounded, get rejected with
@@ -392,6 +412,22 @@ def test_handle_cli_access_request_rejects_reason_that_only_overflows_once_wrapp
     chat_postMessage and unwinding to the generic 500 handler."""
     event = _cli_request_event(
         body={"account": "111111111111", "permission_set": "Foo", "reason": "x" * 1993, "duration": "1"},
+        user_arn="arn:aws:sts::111111111111:assumed-role/AWSReservedSSO_Foo/req@example.com",
+    )
+    result = main_module.handle_cli_access_request(event)
+    assert result["statusCode"] == 400
+
+
+def test_handle_cli_access_request_rejects_reason_that_only_overflows_once_escaped(main_module):
+    """Regression test (#194 A1): the cap used to check len(reason) directly,
+    but the field actually posted is escape_mrkdwn(reason), and escape_mrkdwn
+    expands "&" to "&amp;" -- 5x length. 400 "&" characters is only 400 raw
+    characters, nowhere near the old 1992-char raw-length cap, but expands
+    to a 2000-char escaped string -- 2008 once wrapped in "Reason: ", over
+    Slack's real 2000-char field limit. The old check let this straight
+    through to chat_postMessage."""
+    event = _cli_request_event(
+        body={"account": "111111111111", "permission_set": "Foo", "reason": "&" * 400, "duration": "1"},
         user_arn="arn:aws:sts::111111111111:assumed-role/AWSReservedSSO_Foo/req@example.com",
     )
     result = main_module.handle_cli_access_request(event)
@@ -911,6 +947,54 @@ def test_process_access_request_posts_granted_message_on_success(main_module):
     assert any("permissions granted" in (c.kwargs.get("text") or "").lower() for c in client.chat_postMessage.call_args_list)
 
 
+def test_process_access_request_still_notifies_when_channel_membership_check_fails(main_module):
+    """Regression test (#194 A4): check_if_user_is_in_channel used to be the
+    first statement inside the single shared best-effort try block, so its
+    failure aborted the thread reply, header chat_update, DM, and
+    "Permissions granted" follow-up all at once -- while succeeded (derived
+    from color_coding_emoji, set before any of this) stayed True. A CLI
+    caller would see ok:true for a grant nobody was ever actually told
+    about, and the request would sit granted-but-silently-pending in Slack.
+    A channel-membership-check hiccup must not suppress every other
+    notification."""
+    request = main_module.slack_helpers.RequestForAccess(
+        account_id="111111111111",
+        permission_set_name="FullOrgAdmin",
+        reason="testing",
+        requester_slack_id="U_REQ",
+        permission_duration=main_module.timedelta(hours=1),
+    )
+    requester = MagicMock(id="U_REQ", email="email@domen.com", real_name="Test User")
+    client = MagicMock()
+    client.chat_postMessage.return_value = {"ts": "123.456", "message": {"blocks": []}}
+    client.conversations_members.side_effect = RuntimeError("Slack is briefly unavailable")
+    client.users_info.return_value = MagicMock(
+        data={"user": {"id": "U_REQ", "profile": {"email": "email@domen.com"}, "real_name": "Test User"}}
+    )
+
+    fake_decision = main_module.access_control.AccessRequestDecision(
+        grant=True,
+        reason=main_module.access_control.DecisionReason.SelfApproval,
+        based_on_statements=frozenset(),
+        approvers=frozenset(),
+    )
+    fake_account = main_module.entities.aws.Account(id="111111111111", name="test-account")
+
+    with (
+        patch.object(main_module.access_control, "make_decision_on_access_request", return_value=fake_decision),
+        patch.object(main_module.organizations, "describe_account", return_value=fake_account),
+        patch.object(main_module.slack_helpers.sso, "get_user_principal_id_by_email", return_value=("p-1", False)),
+        patch.object(main_module.access_control, "execute_decision", return_value=True),
+    ):
+        result, succeeded = main_module.process_access_request(request=request, requester=requester, client=client)
+
+    assert succeeded is True
+    # The header chat_update and the "Permissions granted" follow-up must
+    # both still happen despite the channel-membership check failing.
+    assert client.chat_update.call_args_list, "header chat_update should still have run"
+    assert any("permissions granted" in (c.kwargs.get("text") or "").lower() for c in client.chat_postMessage.call_args_list)
+
+
 def test_process_access_request_reports_not_succeeded_when_requires_approval_finds_no_approvers_in_slack(main_module):
     """Regression test: a RequiresApproval decision whose approver emails
     don't resolve to any real Slack user (find_approvers_in_slack returns an
@@ -1047,6 +1131,50 @@ def test_handle_button_click_posts_granted_message_on_success(main_module):
     assert "permissions granted" in update_call.kwargs["text"].lower()
     assert result is not None
     assert main_module.cache_for_dublicate_requests == {}
+
+
+def test_handle_button_click_strips_buttons_before_execute_decision_runs(main_module):
+    """Regression test (#194 A2): the buttons must be removed via their own
+    chat_update *before* execute_decision runs, not only afterward together
+    with the rest of the outcome. cache_for_dublicate_requests can't close
+    this window by itself -- it's per-container in-memory state, so a second
+    approver clicking Approve while execute_decision (specifically
+    create_account_assignment_and_wait_for_result's polling) is still
+    running can land in a different, fresh Lambda container that sees an
+    empty cache and this message's still-live buttons. Verified by having
+    execute_decision itself assert, at the moment it's called, that
+    chat_update was already invoked with blocks that no longer contain the
+    buttons block."""
+    body = _button_click_body()
+    # The shared fixture's mock message has no "buttons" block at all, which
+    # would make the "buttons are gone" assertion below trivially true
+    # regardless of whether removal actually ran -- add one so the test
+    # genuinely proves something was stripped, not just that nothing was
+    # ever there.
+    body["message"]["blocks"].append({"block_id": "buttons", "elements": []})
+    approver = MagicMock(id="U_APPROVER", email="approver@example.com")
+    requester = MagicMock(id="U_REQ", email="req@example.com")
+    client = MagicMock()
+    client.conversations_members.return_value = MagicMock(data={"members": []})
+
+    fake_decision = main_module.access_control.ApproveRequestDecision(grant=True, permit=True, based_on_statements=frozenset())
+
+    def _execute_decision_checks_buttons_already_stripped(**_kwargs):
+        assert client.chat_update.call_count >= 1, "buttons should already have been stripped by now"
+        last_call_blocks = client.chat_update.call_args.kwargs["blocks"]
+        assert not any(b.get("block_id") == "buttons" for b in last_call_blocks)
+        return True
+
+    with (
+        patch.object(main_module.slack_helpers, "get_user", side_effect=[approver, requester]),
+        patch.object(main_module.access_control, "make_decision_on_approve_request", return_value=fake_decision),
+        patch.object(main_module.access_control, "execute_decision", side_effect=_execute_decision_checks_buttons_already_stripped),
+    ):
+        main_module.handle_button_click.__wrapped__(body=body, client=client, context={})
+
+    # Two chat_update calls total: the early button-strip, then the final
+    # outcome update -- not just one at the end.
+    assert client.chat_update.call_count == 2  # noqa: PLR2004
 
 
 def test_handle_button_click_notification_failure_after_a_successful_grant_is_not_reported_as_failure(main_module):

--- a/src/tests/test_sso.py
+++ b/src/tests/test_sso.py
@@ -26,6 +26,24 @@ def test_list_users_collects_users_across_pages():
     paginator.paginate.assert_called_once_with(IdentityStoreId="d-1234567890")
 
 
+def test_list_users_with_cache_returns_the_same_shape_as_list_users_when_cache_is_disabled():
+    """Regression test (#193 item 2): list_users_with_cache must return the
+    exact {"Users": [...]} shape list_users itself does, not the raw cached
+    list get_cached_users/set_cached_users deal in -- find_email_by_username
+    and every other caller expect that key. Cache disabled here so the real,
+    un-mocked with_cache_resilience machinery exercises only the API path,
+    not S3."""
+    client = MagicMock()
+    paginator = MagicMock()
+    client.get_paginator.return_value = paginator
+    paginator.paginate.return_value = [{"Users": [{"UserName": "a"}, {"UserName": "b"}]}]
+    cfg = MagicMock(cache_enabled=False, config_bucket_name="unused")
+
+    result = sso.list_users_with_cache(client, "d-1234567890", MagicMock(), cfg)
+
+    assert result == {"Users": [{"UserName": "a"}, {"UserName": "b"}]}
+
+
 def test_find_email_by_username_matches_exact_username():
     """The realistic case this function exists for: RoleSessionName is an
     Identity Store username, not necessarily an email (e.g. an AD


### PR DESCRIPTION
Addresses the remaining items in #193 and #194's Category A ("Slack-path regressions").

## #193 -- closes it out completely

The core "rejection" bug was already fixed and merged separately (#195). This covers the rest of the issue's "Other things noticed while testing" section:

1. **Expensive identity resolution before cheap validation** -- fixed. Cheap request-body validation now runs before `cli_auth.extract_identity` (an `iam:GetRole` + a full paginated `identitystore:ListUsers` scan), not after.
2. **`sso.list_users` uncached** -- fixed. New `list_users_with_cache`, same S3-backed resilience contract as the account/permission-set catalogs already have. Worth being precise about what this buys: it's a *fallback for API failures*, not a way to skip the scan on the happy path -- `with_cache_resilience` always calls the live API in parallel with the cache read, same as the existing account/permission-set caching. A warm cache doesn't make a normal request faster; it gives the request something to fall back to if the live call throttles.
3. **Two paginated scans per request** -- already resolved as a side effect of #195 removing `has_account_assignment`'s own scan.
4. **A second identity lookup downstream** -- the CLI-specific half of this (the grant target being re-derived independently of the identity verified at submission time) was already fixed by #195, before this PR, so there's nothing to do here for that part. The issue's text also raises a broader, separate observation: the same email-to-UserId lookup runs independently from several places across the *Slack* path (not CLI-specific), which is a real, standing efficiency item -- not precisely covered by #194's B4 (a narrower approval-time-identity-drift correctness edge case) or B9 (an unrelated username-collision finding), despite an earlier version of this description implying otherwise. Left genuinely open, to be scoped properly as part of the #194 pass rather than mis-filed under items that don't actually cover it.
5. **`go build` produces a version-less binary** -- fixed, README now shows the matching `-ldflags`; verified it actually populates `elevator version`'s output, and that the flag names match the real package-level vars in `cmd/elevator/main.go`.
6. **No structured `--json` output** -- remains an explicitly deferred feature, not a fix.

## #194 Category A -- Slack-path regressions

These affect the Slack path already in production, independent of whether the CLI is enabled, so included here rather than held back:

- **A1** -- reason-length cap now checks the *escaped* length (`escape_mrkdwn` can expand a string up to 5x), not the raw length.
- **A2** -- `handle_button_click` strips the Approve/Discard buttons in their own `chat_update` *before* `execute_decision` runs, closing the window where a second approver clicking mid-grant could trigger a duplicate grant.
- **A3** -- `group.py`'s two request-handling functions get the same "grant before green checkmark" + "clear dedup cache on failure too" fixes `main.py`'s equivalents already had.
- **A4** -- a Slack channel-membership-check failure no longer silently suppresses every other notification while still reporting success.
- **A5** -- README note on the email-collision behavior change.

## Verification

- [x] `uv run pytest` -- full suite passes (379 tests)
- [x] Every meaningful fix mechanically verified (reverted, confirmed the corresponding test fails, restored, confirmed it passes again)
- [x] Independently re-verified end to end by a fresh reviewer pass with no access to this description -- confirmed the identity-check reordering has no variable-used-before-defined regression, confirmed the cache shape contract by tracing the real call chain, re-ran compile/pytest/ruff from scratch
- [x] `ruff check` / `ruff format --check` -- clean
- [x] `terraform fmt -check -recursive` -- clean
- [x] `go build` / `go vet` (cmd/elevator) -- clean
- [x] Manually verified the new `-ldflags` build command actually populates `elevator version`'s commit/date fields

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
